### PR TITLE
ZON-2898: Move hex_literal to zeit.cms

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.cms changes
 ================
 
-2.65.3 (unreleased)
+2.66.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Move ``hex_literal`` here from zeit.content.cp (ZON-2898).
 
 
 2.65.2 (2016-03-03)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.cms',
-    version='2.65.3.dev0',
+    version='2.66.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/cms/content/interfaces.py
+++ b/src/zeit/cms/content/interfaces.py
@@ -339,6 +339,15 @@ class ISerie(zope.interface.Interface):
     video = zope.interface.Attribute('')
 
 
+def hex_literal(value):
+    try:
+        int(value, base=16)
+    except ValueError:
+        raise zeit.cms.interfaces.ValidationError(_("Invalid hex literal"))
+    else:
+        return True
+
+
 WRITEABLE_ON_CHECKIN = object()
 WRITEABLE_LIVE = object()
 WRITEABLE_ALWAYS = object()

--- a/src/zeit/cms/content/property.py
+++ b/src/zeit/cms/content/property.py
@@ -132,7 +132,10 @@ class ObjectPathAttributeProperty(ObjectPathProperty):
     def __get__(self, instance, class_):
         if instance is None:
             return self
-        value = self.getNode(instance).get(self.attribute_name)
+        try:
+            value = self.getNode(instance).get(self.attribute_name)
+        except AttributeError:
+            return None
         if value is None:
             if self.field:
                 if self.use_default:
@@ -157,7 +160,11 @@ class ObjectPathAttributeProperty(ObjectPathProperty):
         else:
             if not isinstance(value, basestring):
                 value = unicode(value)
-            self.getNode(instance).set(self.attribute_name, value)
+            node = self.getNode(instance)
+            if node is None:
+                super(ObjectPathAttributeProperty, self).__set__(instance, '')
+                node = self.getNode(instance)
+            node.set(self.attribute_name, value)
 
 
 class MultiPropertyBase(object):


### PR DESCRIPTION
https://github.com/ZeitOnline/zeit.content.image/pull/4
https://github.com/ZeitOnline/zeit.content.cp/pull/9
https://github.com/ZeitOnline/zeit.cms/pull/10
https://github.com/ZeitOnline/zeit.content.article/pull/2