### PR TITLE
Rename `TestContentType` to avoid py.test warnings.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ zeit.cms changes
 
 - ZON-3364: Add ``IWhitelist.locations()`` to abstract location search.
 
+- Rename `TestContentType` to `ExampleContentType` to avoid py.test warnings.
+
+
 
 2.89.0 (2016-09-16)
 -------------------

--- a/src/zeit/cms/admin/tests/test_semantic.py
+++ b/src/zeit/cms/admin/tests/test_semantic.py
@@ -1,5 +1,5 @@
 from zeit.cms.admin.interfaces import IAdjustSemanticPublish
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import datetime
 import pytz
 import zeit.cms.content.interfaces
@@ -11,7 +11,7 @@ class TestSemantic(zeit.cms.testing.ZeitCmsTestCase):
 
     def setUp(self):
         super(TestSemantic, self).setUp()
-        self.content = TestContentType()
+        self.content = ExampleContentType()
 
     def test_adjust_semantic_publish_displays_date_last_published_semantic(
             self):

--- a/src/zeit/cms/asset/browser/form.txt
+++ b/src/zeit/cms/asset/browser/form.txt
@@ -38,7 +38,7 @@ Video...
 Clean up:
 
 >>> zope.interface.classImplementsOnly(
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType,
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType,
 ...     *old_implements)
 
 
@@ -48,7 +48,7 @@ Clean up:
     >>> import zeit.cms.content.browser.interfaces
     >>> import zeit.cms.testcontenttype.testcontenttype
     >>> old_implements = list(zope.interface.implementedBy(
-    ...     zeit.cms.testcontenttype.testcontenttype.TestContentType))
+    ...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType))
     >>> zope.interface.classImplements(
-    ...     zeit.cms.testcontenttype.testcontenttype.TestContentType,
+    ...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType,
     ...     zeit.cms.content.browser.interfaces.IAssetViews)

--- a/src/zeit/cms/browser/tests/test_breadcrumbs.py
+++ b/src/zeit/cms/browser/tests/test_breadcrumbs.py
@@ -27,7 +27,7 @@ class Breadcrumbs(zeit.cms.testing.ZeitCmsTestCase):
         kultur['musik'] = zeit.cms.repository.folder.Folder()
 
     def test_icommonmetadata_lists_ressort_and_sub_ressort(self):
-        content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+        content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
         self.repository['foo'] = content
         content.ressort = u'Kultur'
         content.sub_ressort = u'Musik'
@@ -44,7 +44,7 @@ class Breadcrumbs(zeit.cms.testing.ZeitCmsTestCase):
         ], BreadcrumbsView(content).get_breadcrumbs)
 
     def test_icommonmetadata_without_ressort_omits_item(self):
-        content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+        content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
         self.repository['foo'] = content
         self.assertEqual([
             dict(title='foo',
@@ -53,7 +53,7 @@ class Breadcrumbs(zeit.cms.testing.ZeitCmsTestCase):
         ], BreadcrumbsView(content).get_breadcrumbs)
 
     def test_icommonmetadata_without_sub_ressort_omits_item(self):
-        content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+        content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
         self.repository['foo'] = content
         content.ressort = u'Kultur'
         self.assertEqual([
@@ -66,7 +66,7 @@ class Breadcrumbs(zeit.cms.testing.ZeitCmsTestCase):
         ], BreadcrumbsView(content).get_breadcrumbs)
 
     def test_icommonmetadata_with_invalid_ressort_omits_item(self):
-        content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+        content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
         self.repository['foo'] = content
         content.ressort = u'Kültür'
         self.assertEqual([
@@ -128,7 +128,7 @@ class Breadcrumbs(zeit.cms.testing.ZeitCmsTestCase):
         ], BreadcrumbsView(co).get_breadcrumbs)
 
     def test_temporary_document_name_is_abbreviated_as_new(self):
-        content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+        content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
         self.repository['foo'] = content
         zeit.cms.repository.interfaces.IAutomaticallyRenameable(
             content).renameable = True
@@ -142,7 +142,7 @@ class Breadcrumbs(zeit.cms.testing.ZeitCmsTestCase):
         import zope.app.appsetup.product
         zope.app.appsetup.product._configs['zeit.cms'][
             'breadcrumbs-use-common-metadata'] = 'false'
-        content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+        content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
         self.repository['foo'] = content
         view = BreadcrumbsView(content)
         view.get_breadcrumbs_from_path = mock.Mock()
@@ -153,7 +153,7 @@ class Breadcrumbs(zeit.cms.testing.ZeitCmsTestCase):
         import zope.app.appsetup.product
         del zope.app.appsetup.product._configs['zeit.cms'][
             'breadcrumbs-use-common-metadata']
-        content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+        content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
         self.repository['foo'] = content
         view = BreadcrumbsView(content)
         view.get_breadcrumbs_from_path = mock.Mock()
@@ -164,7 +164,7 @@ class Breadcrumbs(zeit.cms.testing.ZeitCmsTestCase):
         # This makes testing easier
         import zope.app.appsetup.product
         del zope.app.appsetup.product._configs['zeit.cms']
-        content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+        content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
         self.repository['foo'] = content
         view = BreadcrumbsView(content)
         view.get_breadcrumbs_from_path = mock.Mock()

--- a/src/zeit/cms/browser/tests/test_form.py
+++ b/src/zeit/cms/browser/tests/test_form.py
@@ -8,18 +8,18 @@ import zope.publisher.browser
 import zope.schema
 
 
-class Test(object):
+class DummyContext(object):
     """Don't use a mock for this because getting a non-existing attribute from
     a mock yields a non-None value.
     """
 
 
-class TestApplyDefaultValues(unittest.TestCase):
+class ApplyDefaultValuesTests(unittest.TestCase):
 
     def apply(self, interface, context=None):
         from ..form import apply_default_values
         if context is None:
-            context = Test()
+            context = DummyContext()
         apply_default_values(context, interface)
         return context
 
@@ -44,7 +44,7 @@ class TestApplyDefaultValues(unittest.TestCase):
     def test_existing_values_should_not_be_overwritten(self):
         class ITest(zope.interface.Interface):
             number = zope.schema.Int(default=42)
-        context = Test()
+        context = DummyContext()
         context.number = 24
         context = self.apply(ITest, context)
         self.assertEqual(24, context.number)
@@ -62,7 +62,7 @@ class ITestSchema(zope.interface.Interface):
     special.setTaggedValue('placeholder', 'customised')
 
 
-class TestAddForm(zeit.cms.browser.form.AddForm):
+class ExampleAddForm(zeit.cms.browser.form.AddForm):
 
     form_fields = zope.formlib.form.Fields(ITestSchema)
 
@@ -71,7 +71,7 @@ class Placeholder(zeit.cms.testing.ZeitCmsTestCase):
 
     def setUp(self):
         super(Placeholder, self).setUp()
-        self.form = TestAddForm(
+        self.form = ExampleAddForm(
             object(), zope.publisher.browser.TestRequest())
         self.form.factory = object
 

--- a/src/zeit/cms/browser/tests/test_widget.py
+++ b/src/zeit/cms/browser/tests/test_widget.py
@@ -2,7 +2,7 @@
 from zeit.cms.browser.widget import ObjectSequenceDisplayWidget
 from zeit.cms.browser.widget import ObjectSequenceWidget
 from zeit.cms.browser.widget import ReferenceSequenceWidget
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import contextlib
 import mock
 import os
@@ -207,13 +207,13 @@ class TestObjectSequenceWidgetIntegration(
         self.assertEllipsis('...name="field..url"...', result)
 
     def test_widget_should_render_add_view(self):
-        from zeit.cms.testcontenttype.testcontenttype import TestContentType
+        from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
         field = self.get_field()
-        content = TestContentType()
+        content = ExampleContentType()
         content.ressort = u'Politik'
         field = field.bind(content)
         widget = self.get_widget(field)
-        widget.add_type = zeit.cms.testcontenttype.interfaces.ITestContentType
+        widget.add_type = zeit.cms.testcontenttype.interfaces.IExampleContentType
         self.assert_ellipsis(
             '...<a target="_blank"'
             '...href="http://127.0.0.1/repository/politik/'
@@ -653,15 +653,15 @@ class TestDropObjectWidgetIntegration(
         self.assertEllipsis('...name="field..url"...', widget())
 
     def test_widget_should_render_add_view(self):
-        from zeit.cms.testcontenttype.testcontenttype import TestContentType
+        from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
         choice = self.get_choice()
         request = zope.publisher.browser.TestRequest()
-        content = TestContentType()
+        content = ExampleContentType()
         content.ressort = u'Politik'
         choice = choice.bind(content)
         widget = zeit.cms.browser.widget.DropObjectWidget(
             choice, choice.source, request)
-        widget.add_type = zeit.cms.testcontenttype.interfaces.ITestContentType
+        widget.add_type = zeit.cms.testcontenttype.interfaces.IExampleContentType
         self.assertEllipsis(
             '...<a target="_blank"'
             '...href="http://127.0.0.1/repository/politik/'
@@ -864,11 +864,11 @@ class TestReferenceSequenceWidget(zeit.cms.testing.ZeitCmsTestCase):
 
     def setUp(self):
         super(TestReferenceSequenceWidget, self).setUp()
-        TestContentType.references = \
+        ExampleContentType.references = \
             zeit.cms.content.reference.ReferenceProperty(
                 '.body.references.reference', 'related')
-        self.repository['content'] = TestContentType()
-        self.repository['target'] = TestContentType()
+        self.repository['content'] = ExampleContentType()
+        self.repository['target'] = ExampleContentType()
 
         class FakeSource(object):
 
@@ -883,7 +883,7 @@ class TestReferenceSequenceWidget(zeit.cms.testing.ZeitCmsTestCase):
         self.field = self.field.bind(self.repository['content'])
 
     def tearDown(self):
-        del TestContentType.references
+        del ExampleContentType.references
         super(TestReferenceSequenceWidget, self).tearDown()
 
     def test_invalid_unique_id_fails_validation(self):

--- a/src/zeit/cms/browser/tests/test_widget.py
+++ b/src/zeit/cms/browser/tests/test_widget.py
@@ -312,6 +312,7 @@ class TestObjectSequenceWidgetJavascript(zeit.cms.testing.SeleniumTestCase):
         s.dragAndDropToObject('id=drag2', 'id=testwidget')
         s.waitForElementPresent('css=li.element')
         s.waitForElementPresent('css=a[rel=remove]')
+        s.mouseMove('css=a[rel=remove]')
         s.click('css=a[rel=remove]')
         s.waitForElementNotPresent('css=li.element')
 
@@ -320,6 +321,7 @@ class TestObjectSequenceWidgetJavascript(zeit.cms.testing.SeleniumTestCase):
         s.dragAndDropToObject('id=drag', 'id=testwidget')
         s.waitForElementPresent("//input[@name='testwidget.0']")
         s.waitForElementPresent('css=a[rel=remove]')
+        s.mouseMove('css=a[rel=remove]')
         s.click('css=a[rel=remove]')
         s.waitForElementNotPresent("//input[@name='testwidget.0']")
 
@@ -328,6 +330,7 @@ class TestObjectSequenceWidgetJavascript(zeit.cms.testing.SeleniumTestCase):
         s.dragAndDropToObject('id=drag', 'id=testwidget')
         s.waitForValue("//input[@name='testwidget.count']", '1')
         s.waitForElementPresent('css=a[rel=remove]')
+        s.mouseMove('css=a[rel=remove]')
         s.click('css=a[rel=remove]')
         s.waitForValue("//input[@name='testwidget.count']", '0')
 

--- a/src/zeit/cms/checkout/README.txt
+++ b/src/zeit/cms/checkout/README.txt
@@ -333,7 +333,7 @@ Provoke a conflict:
 
 >>> import zeit.cms.testcontenttype.testcontenttype
 >>> content.__parent__[content.__name__] = (
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType())
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType())
 
 Checking in is not possible just like that:
 

--- a/src/zeit/cms/clipboard/browser/tests/test_clipboard.py
+++ b/src/zeit/cms/clipboard/browser/tests/test_clipboard.py
@@ -1,4 +1,4 @@
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import zeit.cms.clipboard.browser.clipboard
 import zeit.cms.clipboard.interfaces
 import zeit.cms.testing
@@ -16,7 +16,7 @@ class ClipboardTest(zeit.cms.testing.ZeitCmsTestCase):
 
     def test_get_type_of_content_object(self):
         folder = self.clipboard.addClip('Favoriten')
-        self.repository['test'] = TestContentType()
+        self.repository['test'] = ExampleContentType()
         content = self.repository['test']
         self.clipboard.addContent(folder, content, 'testname', insert=True)
         clip = list(folder.values())[0]

--- a/src/zeit/cms/content/contentuuid.txt
+++ b/src/zeit/cms/content/contentuuid.txt
@@ -132,7 +132,7 @@ Objects also get an UUID when they're added to the repository:
 >>> repository = zope.component.getUtility(
 ...     zeit.cms.repository.interfaces.IRepository)
 >>> repository['content'] = (
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType())
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType())
 >>> zeit.cms.content.interfaces.IUUID(repository['content']).id
 '{urn:uuid:1029cf63-5823-456c-bbd4-1a98cdfa25c7}'
 

--- a/src/zeit/cms/content/dav.txt
+++ b/src/zeit/cms/content/dav.txt
@@ -184,7 +184,7 @@ Create a dav property and set an invalid value:
 >>> import zeit.cms.testcontenttype.testcontenttype
 >>> dav_prop = zeit.cms.content.dav.DAVProperty(
 ...     field, 'my-ns', 'myname')
->>> testcontent = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+>>> testcontent = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
 >>> testcontent.uniqueId = u'http://xml.zeit.de/foo'
 >>> properties = zeit.connector.interfaces.IWebDAVProperties(testcontent)
 >>> properties[('myname', 'my-ns')] = u'f\xfcblas'
@@ -194,7 +194,7 @@ When we try to get the data we'll get the default value (None):
 >>> dav_prop.__get__(testcontent, object) is None
 True
 >>> print log.getvalue()
-Could not parse DAV property value u'f\xfcblas' for TestContentType.myname at
+Could not parse DAV property value u'f\xfcblas' for ExampleContentType.myname at
 http://xml.zeit.de/foo [ValueError: (...time data ...not match format...)].
 Using default None instead.
 

--- a/src/zeit/cms/content/metadata.txt
+++ b/src/zeit/cms/content/metadata.txt
@@ -5,7 +5,7 @@ The common metadata is used for many content types. Test a few things on the
 test type[#functional]_:
 
 >>> import zeit.cms.testcontenttype.testcontenttype
->>> content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+>>> content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
 
 Set "comments allowed" from common metadata:
 

--- a/src/zeit/cms/content/sources.txt
+++ b/src/zeit/cms/content/sources.txt
@@ -2,7 +2,7 @@ Sources
 =======
 
 >>> import zeit.cms.testcontenttype.testcontenttype
->>> content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+>>> content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
 
 Serie
 +++++
@@ -142,7 +142,7 @@ that we get *all* sub navigation elements
  u'Nahost',
  u'US-Wahl']
 
-Select 'Deutschland'. Since ITestContentType is an ICMSContent we still get
+Select 'Deutschland'. Since IExampleContentType is an ICMSContent we still get
 everything. This is actually not desired but is the only way we can avoid
 saving the ressort first and then the subressort:
 

--- a/src/zeit/cms/content/tests/test_add.py
+++ b/src/zeit/cms/content/tests/test_add.py
@@ -1,4 +1,4 @@
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import zeit.cms.browser.interfaces
 import zeit.cms.content.add
 import zeit.cms.content.interfaces
@@ -18,7 +18,7 @@ class ContentAdderTest(zeit.cms.testing.ZeitCmsTestCase):
     def test_parameters_should_be_passed_in_url(self):
         adder = zeit.cms.content.add.ContentAdder(
             self.request,
-            type_=zeit.cms.testcontenttype.interfaces.ITestContentType,
+            type_=zeit.cms.testcontenttype.interfaces.IExampleContentType,
             ressort='wirtschaft', sub_ressort='geldanlage',
             year='2009', month='02')
         self.assertEqual(
@@ -31,7 +31,7 @@ class ContentAdderTest(zeit.cms.testing.ZeitCmsTestCase):
     def test_sub_ressort_is_optional(self):
         adder = zeit.cms.content.add.ContentAdder(
             self.request,
-            type_=zeit.cms.testcontenttype.interfaces.ITestContentType,
+            type_=zeit.cms.testcontenttype.interfaces.IExampleContentType,
             ressort='wirtschaft', year='2009', month='02')
         self.assertEqual(
             'http://127.0.0.1/repository/wirtschaft/2009-02/'
@@ -42,7 +42,7 @@ class ContentAdderTest(zeit.cms.testing.ZeitCmsTestCase):
     def test_ressort_and_sub_ressort_are_optional(self):
         adder = zeit.cms.content.add.ContentAdder(
             self.request,
-            type_=zeit.cms.testcontenttype.interfaces.ITestContentType,
+            type_=zeit.cms.testcontenttype.interfaces.IExampleContentType,
             year='2009', month='02')
         self.assertEqual(
             'http://127.0.0.1/repository/2009-02/'
@@ -54,12 +54,12 @@ class ContentAdderTest(zeit.cms.testing.ZeitCmsTestCase):
 
         zope.component.getSiteManager().registerAdapter(
             lambda *args: self.repository['foo'],
-            (zeit.cms.testcontenttype.interfaces.ITestContentType,
+            (zeit.cms.testcontenttype.interfaces.IExampleContentType,
              zeit.cms.content.interfaces.IContentAdder),
             zeit.cms.content.interfaces.IAddLocation)
         adder = zeit.cms.content.add.ContentAdder(
             self.request,
-            type_=zeit.cms.testcontenttype.interfaces.ITestContentType)
+            type_=zeit.cms.testcontenttype.interfaces.IExampleContentType)
         self.assertEqual(
             'http://127.0.0.1/repository/foo/'
             '@@zeit.cms.testcontenttype.Add?', adder())
@@ -75,7 +75,7 @@ class RessortYearFolderTest(zeit.cms.testing.ZeitCmsTestCase):
         adder = zeit.cms.content.add.ContentAdder(
             ANY, ressort='wirtschaft', year='2009', month='2')
         folder = zope.component.getMultiAdapter(
-            (TestContentType(), adder),
+            (ExampleContentType(), adder),
             zeit.cms.content.interfaces.IAddLocation)
         self.assertEqual(self.repository['wirtschaft']['2009-02'], folder)
 
@@ -84,6 +84,6 @@ class RessortYearFolderTest(zeit.cms.testing.ZeitCmsTestCase):
         adder = zeit.cms.content.add.ContentAdder(
             ANY, ressort='wirtschaft', year='2009', month='02')
         folder = zope.component.getMultiAdapter(
-            (TestContentType(), adder),
+            (ExampleContentType(), adder),
             zeit.cms.content.interfaces.IAddLocation)
         self.assertEqual(self.repository['wirtschaft']['2009-02'], folder)

--- a/src/zeit/cms/content/tests/test_metadata.py
+++ b/src/zeit/cms/content/tests/test_metadata.py
@@ -1,6 +1,6 @@
 from zeit.cms.checkout.helper import checked_out
 import zeit.cms.testcontenttype.interfaces
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import zeit.cms.testing
 import zeit.content.article.testing
 import zope.lifecycleevent
@@ -13,7 +13,7 @@ class ChannelCopying(zeit.cms.testing.ZeitCmsTestCase):
             co.ressort = u'Deutschland'
             zope.lifecycleevent.modified(
                 co, zope.lifecycleevent.Attributes(
-                    zeit.cms.testcontenttype.interfaces.ITestContentType,
+                    zeit.cms.testcontenttype.interfaces.IExampleContentType,
                     'ressort'))
             self.assertEqual((('Deutschland', None),), co.channels)
 
@@ -23,7 +23,7 @@ class ChannelCopying(zeit.cms.testing.ZeitCmsTestCase):
             co.ressort = u'Deutschland'
             zope.lifecycleevent.modified(
                 co, zope.lifecycleevent.Attributes(
-                    zeit.cms.testcontenttype.interfaces.ITestContentType,
+                    zeit.cms.testcontenttype.interfaces.IExampleContentType,
                     'ressort'))
             self.assertEqual((('International', None),
                               ('Deutschland', None)), co.channels)
@@ -34,18 +34,18 @@ class ChannelCopying(zeit.cms.testing.ZeitCmsTestCase):
             co.ressort = u'Deutschland'
             zope.lifecycleevent.modified(
                 co, zope.lifecycleevent.Attributes(
-                    zeit.cms.testcontenttype.interfaces.ITestContentType,
+                    zeit.cms.testcontenttype.interfaces.IExampleContentType,
                     'ressort'))
             self.assertEqual((('Deutschland', None),), co.channels)
 
     def test_channels_are_not_set_if_product_forbids_it(self):
-        article = TestContentType()
+        article = ExampleContentType()
         article.product = zeit.cms.content.sources.Product(u'ZEI')
         self.repository['testcontent'] = article
         with checked_out(self.repository['testcontent']) as co:
             co.ressort = u'Deutschland'
             zope.lifecycleevent.modified(
                 co, zope.lifecycleevent.Attributes(
-                    zeit.cms.testcontenttype.interfaces.ITestContentType,
+                    zeit.cms.testcontenttype.interfaces.IExampleContentType,
                     'ressort'))
             self.assertEqual((), co.channels)

--- a/src/zeit/cms/content/tests/test_property.py
+++ b/src/zeit/cms/content/tests/test_property.py
@@ -1,5 +1,5 @@
 from zeit.cms.checkout.helper import checked_out
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import mock
 import unittest
 import zeit.cms.testing

--- a/src/zeit/cms/content/tests/test_reference.py
+++ b/src/zeit/cms/content/tests/test_reference.py
@@ -3,7 +3,7 @@ from zeit.cms.checkout.helper import checked_out
 from zeit.cms.content.reference import ReferenceProperty
 from zeit.cms.content.reference import SingleReferenceProperty
 from zeit.cms.interfaces import ICMSContent
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import urllib
 import urllib2
 import zeit.cms.content.property
@@ -24,12 +24,12 @@ class ReferenceFixture(object):
 
     def setUp(self):
         super(ReferenceFixture, self).setUp()
-        TestContentType.references = ReferenceProperty(
+        ExampleContentType.references = ReferenceProperty(
             '.body.references.reference', 'test')
         zope.security.protectclass.protectName(
-            TestContentType, 'references', 'zope.Public')
+            ExampleContentType, 'references', 'zope.Public')
         zope.security.protectclass.protectSetAttribute(
-            TestContentType, 'references', 'zope.Public')
+            ExampleContentType, 'references', 'zope.Public')
 
         zope.security.protectclass.protectLikeUnto(
             ExampleReference, zeit.cms.content.reference.Reference)
@@ -42,11 +42,11 @@ class ReferenceFixture(object):
             zeit.cms.related.related.BasicReference, name='test')
         self.zca.patch_adapter(ExampleReference, name='test')
 
-        self.repository['content'] = TestContentType()
-        self.repository['target'] = TestContentType()
+        self.repository['content'] = ExampleContentType()
+        self.repository['target'] = ExampleContentType()
 
     def tearDown(self):
-        del TestContentType.references
+        del ExampleContentType.references
         super(ReferenceFixture, self).tearDown()
 
 
@@ -70,7 +70,7 @@ class ReferencePropertyTest(
         self.assertEqual((), content.references)
 
     def test_setting_different_references_is_stored_correctly(self):
-        self.repository['other'] = TestContentType()
+        self.repository['other'] = ExampleContentType()
         content = self.repository['content']
         content.references = (
             content.references.create(self.repository['target']),
@@ -192,7 +192,7 @@ class SingleReferenceFixture(ReferenceFixture):
 
     def setUp(self):
         super(SingleReferenceFixture, self).setUp()
-        TestContentType.references = SingleReferenceProperty(
+        ExampleContentType.references = SingleReferenceProperty(
             '.body.references.reference', 'test')
 
 
@@ -240,7 +240,7 @@ class MultiResourceTest(
 
     def setUp(self):
         super(MultiResourceTest, self).setUp()
-        TestContentType.related = zeit.cms.content.reference.MultiResource(
+        ExampleContentType.related = zeit.cms.content.reference.MultiResource(
             '.body.references.reference', 'test')
 
     def test_set_and_retrieve_referenced_objects_as_tuple(self):
@@ -265,7 +265,7 @@ class MultiResourceTest(
             pass
 
         body = self.repository['content'].xml['body']
-        # Since TestContentType (our reference target) implements
+        # Since ExampleContentType (our reference target) implements
         # ICommonMetadata, its XMLReferenceUpdater will write 'title' (among
         # others) into the XML.
         self.assertEqual(
@@ -277,7 +277,7 @@ class SingleResourceTest(
 
     def setUp(self):
         super(SingleResourceTest, self).setUp()
-        TestContentType.related = zeit.cms.content.reference.SingleResource(
+        ExampleContentType.related = zeit.cms.content.reference.SingleResource(
             '.body.references.reference', 'test')
 
     def test_set_and_retrieve_referenced_objects_directly(self):
@@ -285,7 +285,7 @@ class SingleResourceTest(
         content._p_jar = Mock()  # make _p_changed work
         content.related = self.repository['target']
         self.assertTrue(content._p_changed)
-        self.assertIsInstance(content.related, TestContentType)
+        self.assertIsInstance(content.related, ExampleContentType)
         self.assertEqual(
             'http://xml.zeit.de/target', content.related.uniqueId)
 
@@ -302,7 +302,7 @@ class SingleResourceTest(
             pass
 
         body = self.repository['content'].xml['body']
-        # Since TestContentType (our reference target) implements
+        # Since ExampleContentType (our reference target) implements
         # ICommonMetadata, its XMLReferenceUpdater will write 'title' (among
         # others) into the XML.
         self.assertEqual(

--- a/src/zeit/cms/content/tests/test_semanticchange.py
+++ b/src/zeit/cms/content/tests/test_semanticchange.py
@@ -4,8 +4,8 @@ import zeit.cms.testing
 class TestSemanticChange(zeit.cms.testing.ZeitCmsTestCase):
 
     def get_content(self):
-        from zeit.cms.testcontenttype.testcontenttype import TestContentType
-        return TestContentType()
+        from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
+        return ExampleContentType()
 
     def test_lsc_should_be_set_on_creation(self):
         from zeit.cms.content.interfaces import ISemanticChange

--- a/src/zeit/cms/content/tests/test_sources.py
+++ b/src/zeit/cms/content/tests/test_sources.py
@@ -1,6 +1,6 @@
 from mock import Mock
 from zeit.cms.checkout.helper import checked_out
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import gocept.lxml.objectify
 import zeit.cms.content.sources
 import zeit.cms.interfaces
@@ -69,7 +69,7 @@ class AddableCMSContentTypeSourceTest(zeit.cms.testing.ZeitCmsTestCase):
 class StorystreamReferenceTest(zeit.cms.testing.ZeitCmsTestCase):
 
     def test_resolves_reference_from_source_config(self):
-        self.repository['storystream'] = TestContentType()
+        self.repository['storystream'] = ExampleContentType()
         with checked_out(self.repository['testcontent']) as co:
             co.storystreams = (zeit.cms.content.sources.StorystreamSource()(
                 None).find('test'),)

--- a/src/zeit/cms/content/xmlsupport.txt
+++ b/src/zeit/cms/content/xmlsupport.txt
@@ -14,9 +14,9 @@ Let's mark testcontent as IDAVPropertiesInXML:
 >>> import zeit.cms.content.interfaces
 >>> import zeit.cms.testcontenttype.testcontenttype
 >>> old_implements = list(zope.interface.implementedBy(
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType))
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType))
 >>> zope.interface.classImplements(
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType,
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType,
 ...     zeit.cms.content.interfaces.IDAVPropertiesInXML)
 
 
@@ -133,7 +133,7 @@ We can now still change the values here w/o getting an error:
 Clean up:
 
 >>> zope.interface.classImplementsOnly(
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType,
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType,
 ...     *old_implements)
 
 .. [#functional]

--- a/src/zeit/cms/redirect/tests/test_move.py
+++ b/src/zeit/cms/redirect/tests/test_move.py
@@ -1,7 +1,7 @@
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.redirect.interfaces import IRenameInfo
 from zeit.cms.related.interfaces import IRelatedContent
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import gocept.async.tests
 import lxml.etree
 import mock
@@ -12,9 +12,9 @@ import zope.copypastemove.interfaces
 class MoveTest(zeit.cms.testing.ZeitCmsTestCase):
 
     def test_renaming_referenced_obj_updates_uniqueId_in_referencing_obj(self):
-        self.repository['2007']['article'] = TestContentType()
+        self.repository['2007']['article'] = ExampleContentType()
         article = self.repository['2007']['article']
-        self.repository['referencing'] = TestContentType()
+        self.repository['referencing'] = ExampleContentType()
         with checked_out(self.repository['referencing']) as co:
             IRelatedContent(co).related = (article,)
 
@@ -32,7 +32,7 @@ class MoveTest(zeit.cms.testing.ZeitCmsTestCase):
             lxml.etree.tostring(referencing.xml, pretty_print=True))
 
     def test_rename_stores_old_name_on_dav_property(self):
-        self.repository['article'] = TestContentType()
+        self.repository['article'] = ExampleContentType()
         zope.copypastemove.interfaces.IObjectMover(
             self.repository['article']).moveTo(self.repository, 'changed')
         gocept.async.tests.process()
@@ -45,6 +45,6 @@ class MoveTest(zeit.cms.testing.ZeitCmsTestCase):
         # Since the IObjectMover for IRepository is a trusted adapter,
         # we don't usually notice that we need a security declaration for
         # IRenameInfo.
-        self.repository['article'] = TestContentType()
+        self.repository['article'] = ExampleContentType()
         wrapped = zope.security.proxy.ProxyFactory(self.repository['article'])
         self.assertEqual((), IRenameInfo(wrapped).previous_uniqueIds)

--- a/src/zeit/cms/related/related.txt
+++ b/src/zeit/cms/related/related.txt
@@ -7,7 +7,7 @@ Content can be related. The default way is relating xml
 content[#functionaltest]_:
 
 >>> import zeit.cms.testcontenttype.testcontenttype
->>> content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+>>> content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
 
 Add content to repository:
 
@@ -40,7 +40,7 @@ The source has not changed:
 Add a related content:
 
 >>> related_content = (
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType())
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType())
 >>> repository['related'] = related_content
 >>> related.related = (related_content, )
 
@@ -66,7 +66,7 @@ Let's have a look at the source:
 </testtype>
 
 >>> related.related
-(<zeit.cms.testcontenttype.testcontenttype.TestContentType...>,)
+(<zeit.cms.testcontenttype.testcontenttype.ExampleContentType...>,)
 >>> related.related[0].uniqueId
 u'http://xml.zeit.de/related'
 
@@ -96,7 +96,7 @@ Assigning the same content object again doesn't change the xml:
 Let's add another related content:
 
 >>> related_content2 = (
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType())
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType())
 >>> repository['related2'] = related_content2
 >>> related.related = (related_content, related_content2)
 >>> print lxml.etree.tostring(content.xml, pretty_print=True)

--- a/src/zeit/cms/related/tests/test_interfaces.py
+++ b/src/zeit/cms/related/tests/test_interfaces.py
@@ -20,10 +20,10 @@ class Source(zeit.cms.testing.ZeitCmsTestCase):
     def test_valid_interfaces_are_returned_in_order(self):
         self.product_config['relatable-content-types'] = (
             'zeit.cms.repository.interfaces.IFolder '
-            'zeit.cms.testcontenttype.interfaces.ITestContentType')
+            'zeit.cms.testcontenttype.interfaces.IExampleContentType')
         self.assertEqual(
             [zeit.cms.repository.interfaces.IFolder,
-             zeit.cms.testcontenttype.interfaces.ITestContentType],
+             zeit.cms.testcontenttype.interfaces.IExampleContentType],
             relatableContentSource.get_check_interfaces())
 
     def test_invalid_interface_raises_typeerror(self):

--- a/src/zeit/cms/relation/README.txt
+++ b/src/zeit/cms/relation/README.txt
@@ -45,7 +45,7 @@ We could ask for b's relations:
 >>> len(res)
 1
 >>> res
-[<zeit.cms.testcontenttype.testcontenttype.TestContentType...>]
+[<zeit.cms.testcontenttype.testcontenttype.ExampleContentType...>]
 >>> res[0].uniqueId
 u'http://xml.zeit.de/a'
 
@@ -83,7 +83,7 @@ longer reference a anyway (because we cannot find a anymore)
 .. [#none-unique-id-yields-nothing] When an object with a unique id of "None"
     is queried, nothing will be returned:
 
-    >>> no_uid = TestContentType()
+    >>> no_uid = ExampleContentType()
     >>> sorted(relations.get_relations(no_uid))
     []
 
@@ -324,12 +324,12 @@ Clean up:
 
 .. [#createtestcontent] Create some testcontent:
 
-    >>> from zeit.cms.testcontenttype.testcontenttype import TestContentType
+    >>> from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 
-    >>> repository['a'] = TestContentType()
-    >>> repository['b'] = TestContentType()
-    >>> repository['c'] = TestContentType()
-    >>> repository['d'] = TestContentType()
+    >>> repository['a'] = ExampleContentType()
+    >>> repository['b'] = ExampleContentType()
+    >>> repository['c'] = ExampleContentType()
+    >>> repository['d'] = ExampleContentType()
 
 
 .. [#cleancatalog] Clean the catalog:

--- a/src/zeit/cms/relation/browser/README.txt
+++ b/src/zeit/cms/relation/browser/README.txt
@@ -16,7 +16,7 @@ Displaying references
 >>> zeit.cms.testing.set_site()
 >>> repository = zope.component.getUtility(
 ...     zeit.cms.repository.interfaces.IRepository)
->>> content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+>>> content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
 >>> content.title = 'Some Article'
 >>> repository['test2'] = content
 
@@ -38,7 +38,7 @@ Displaying references
 Clean up:
 
 >>> zope.interface.classImplementsOnly(
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType,
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType,
 ...     *old_implements)
 
 
@@ -48,7 +48,7 @@ Clean up:
     >>> import zeit.cms.content.browser.interfaces
     >>> import zeit.cms.testcontenttype.testcontenttype
     >>> old_implements = list(zope.interface.implementedBy(
-    ...     zeit.cms.testcontenttype.testcontenttype.TestContentType))
+    ...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType))
     >>> zope.interface.classImplements(
-    ...     zeit.cms.testcontenttype.testcontenttype.TestContentType,
+    ...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType,
     ...     zeit.cms.content.browser.interfaces.IAssetViews)

--- a/src/zeit/cms/repository/tests/test_repository.py
+++ b/src/zeit/cms/repository/tests/test_repository.py
@@ -99,9 +99,9 @@ class ViviURLToContent(unittest.TestCase):
 class UniqueIdToContentIntegration(zeit.cms.testing.ZeitCmsTestCase):
 
     def test_xml_zeit_de_is_translated_to_content_object(self):
-        from zeit.cms.testcontenttype.testcontenttype import TestContentType
+        from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
         self.assertIsInstance(
-            ICMSContent('http://xml.zeit.de/testcontent'), TestContentType)
+            ICMSContent('http://xml.zeit.de/testcontent'), ExampleContentType)
 
     def test_www_zeit_de_is_wired_up_and_delegates_to_xml_zeit_de(self):
         self.assertEqual(

--- a/src/zeit/cms/section/ftesting.zcml
+++ b/src/zeit/cms/section/ftesting.zcml
@@ -20,7 +20,7 @@
 
   <adapter
     factory=".testing.IExampleSection"
-    for="..testcontenttype.interfaces.ITestContentType"
+    for="..testcontenttype.interfaces.IExampleContentType"
     provides=".interfaces.IRessortSection"
     name="Sport"
     />

--- a/src/zeit/cms/section/testing.py
+++ b/src/zeit/cms/section/testing.py
@@ -35,6 +35,6 @@ class IExampleContent(zeit.cms.interfaces.ICMSContent,
     pass
 
 
-class IExampleTestcontent(zeit.cms.testcontenttype.interfaces.ITestContentType,
+class IExampleTestcontent(zeit.cms.testcontenttype.interfaces.IExampleContentType,
                           zeit.cms.section.interfaces.ISectionMarker):
     pass

--- a/src/zeit/cms/section/tests/test_section.py
+++ b/src/zeit/cms/section/tests/test_section.py
@@ -1,6 +1,6 @@
 from zeit.cms.repository.folder import Folder
 from zeit.cms.section.interfaces import ISection
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import transaction
 import zeit.cms.checkout.helper
 import zeit.cms.section.testing
@@ -21,7 +21,7 @@ class ApplyMarkersTest(zeit.cms.testing.FunctionalTestCase):
             zeit.cms.section.testing.IExampleTestcontent.providedBy(obj))
 
     def test_specific_types_are_marked_with_type_specific_interface(self):
-        self.repository['example']['test'] = TestContentType()
+        self.repository['example']['test'] = ExampleContentType()
         obj = self.repository['example']['test']
         self.assertTrue(
             zeit.cms.section.testing.IExampleContent.providedBy(obj))
@@ -29,7 +29,7 @@ class ApplyMarkersTest(zeit.cms.testing.FunctionalTestCase):
             zeit.cms.section.testing.IExampleTestcontent.providedBy(obj))
 
     def test_type_markers_are_more_specific_than_general_markers(self):
-        self.repository['example']['test'] = TestContentType()
+        self.repository['example']['test'] = ExampleContentType()
         obj = self.repository['example']['test']
         provides = list(zope.interface.providedBy(obj))
         self.assertLess(
@@ -45,7 +45,7 @@ class ApplyMarkersTest(zeit.cms.testing.FunctionalTestCase):
         # a folder /without/ it being marked, so we can check that the marking
         # happens during checkout.
         self.repository['folder'] = zeit.cms.repository.folder.Folder()
-        self.repository['folder']['test'] = TestContentType()
+        self.repository['folder']['test'] = ExampleContentType()
         # we cannot change the DAV-Properties of an existing folder
         # while it's checked in -- and checking out folders is not supported,
         # so we *replace* the folder object... don't try this at home, folks.
@@ -73,7 +73,7 @@ class ApplyMarkersTest(zeit.cms.testing.FunctionalTestCase):
             zeit.cms.section.interfaces.IZONContent.providedBy(obj))
 
     def test_content_is_marked_according_to_ressort(self):
-        obj = TestContentType()
+        obj = ExampleContentType()
         obj.ressort = u'Sport'
 
         self.repository['sport'] = obj
@@ -95,6 +95,6 @@ class FindSectionTest(zeit.cms.testing.FunctionalTestCase):
                          ISection(self.repository['testcontent']))
 
     def test_content_inside_section_returns_that_interface(self):
-        self.repository['example']['content'] = TestContentType()
+        self.repository['example']['content'] = ExampleContentType()
         section = ISection(self.repository['example']['content'])
         self.assertEqual(zeit.cms.section.testing.IExampleSection, section)

--- a/src/zeit/cms/syndication/README.txt
+++ b/src/zeit/cms/syndication/README.txt
@@ -113,7 +113,7 @@ Event: <zeit.cms.syndication.interfaces.ContentSyndicatedEvent...>
      Content: http://xml.zeit.de/testcontent
 >>> target = repository['politik.feed']
 >>> list(target)
-[<zeit.cms.testcontenttype.testcontenttype.TestContentType...>]
+[<zeit.cms.testcontenttype.testcontenttype.ExampleContentType...>]
 >>> list(target)[0].uniqueId == content.uniqueId
 True
 
@@ -188,7 +188,7 @@ Checkout content, change a teaser and check back in:
 ...     content).checkout()
 >>> checked_out.teaserTitle = u'nice Teaser Title'
 >>> zeit.cms.checkout.interfaces.ICheckinManager(checked_out).checkin()
-<zeit.cms.testcontenttype.testcontenttype.TestContentType...>
+<zeit.cms.testcontenttype.testcontenttype.ExampleContentType...>
 >>> import gocept.async.tests
 >>> gocept.async.tests.process('events')
 
@@ -222,7 +222,7 @@ updated:
 ...     content).checkout()
 >>> checked_out.teaserTitle = u'nice other Teaser Title'
 >>> zeit.cms.checkout.interfaces.ICheckinManager(checked_out).checkin()
-<zeit.cms.testcontenttype.testcontenttype.TestContentType...>
+<zeit.cms.testcontenttype.testcontenttype.ExampleContentType...>
 
 The feed was not updated:
 
@@ -256,7 +256,7 @@ automatically. Forbid the automatic update:
 >>> checked_out.automaticMetadataUpdateDisabled = frozenset([
 ...     repository['politik.feed']])
 >>> zeit.cms.checkout.interfaces.ICheckinManager(checked_out).checkin()
-<zeit.cms.testcontenttype.testcontenttype.TestContentType...>
+<zeit.cms.testcontenttype.testcontenttype.ExampleContentType...>
 
 The feed has not changed this time:
 

--- a/src/zeit/cms/syndication/feed.txt
+++ b/src/zeit/cms/syndication/feed.txt
@@ -97,7 +97,7 @@ Let's also add an object from the repository:
 >>> list(feed.keys())
 ['http://xml.zeit.de/testcontent', 'art3', 'art1']
 >>> list(feed)
-[<zeit.cms.testcontenttype.testcontenttype.TestContentType...>,
+[<zeit.cms.testcontenttype.testcontenttype.ExampleContentType...>,
  <zeit.cms.syndication.feed.FakeEntry...>,
  <zeit.cms.syndication.feed.FakeEntry...>]
 

--- a/src/zeit/cms/testcontenttype/README.txt
+++ b/src/zeit/cms/testcontenttype/README.txt
@@ -14,7 +14,7 @@ Setup ftest:
 Instantiate and verify the inital xml:
 
 >>> import zeit.cms.testcontenttype.testcontenttype
->>> content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+>>> content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
 >>> import zope.component
 >>> import zeit.cms.repository.interfaces
 >>> repository = zope.component.getUtility(
@@ -28,13 +28,13 @@ Instantiate and verify the inital xml:
   <body/>
 </testtype>
 
-The type provides the ITestContentType and IEditorialContent interfaces:
+The type provides the IExampleContentType and IEditorialContent interfaces:
 
 >>> import zope.interface.verify
 >>> import zeit.cms.interfaces
 >>> import zeit.cms.testcontenttype.interfaces
 >>> zope.interface.verify.verifyObject(
-...     zeit.cms.testcontenttype.interfaces.ITestContentType, content)
+...     zeit.cms.testcontenttype.interfaces.IExampleContentType, content)
 True
 >>> zope.interface.verify.verifyObject(
 ...     zeit.cms.interfaces.IEditorialContent, content)

--- a/src/zeit/cms/testcontenttype/browser/configure.zcml
+++ b/src/zeit/cms/testcontenttype/browser/configure.zcml
@@ -4,21 +4,21 @@
   i18n_domain="zeit.cms">
 
   <browser:defaultView
-    for="..interfaces.ITestContentType"
+    for="..interfaces.IExampleContentType"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     name="view.html"
     />
 
   <browser:view
     name="view.html"
-    for="..interfaces.ITestContentType"
+    for="..interfaces.IExampleContentType"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     permission="zope.View"
     class="zeit.cms.content.browser.form.CommonMetadataDisplayForm"
     />
 
   <browser:menuItem
-    for="..interfaces.ITestContentType"
+    for="..interfaces.IExampleContentType"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     action="@@view.html"
     menu="zeit-context-views"
@@ -29,7 +29,7 @@
 
   <browser:page
     name="edit.html"
-    for="..interfaces.ITestContentType"
+    for="..interfaces.IExampleContentType"
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     class=".form.Edit"
     permission="zeit.EditContent"

--- a/src/zeit/cms/testcontenttype/browser/form.py
+++ b/src/zeit/cms/testcontenttype/browser/form.py
@@ -6,7 +6,7 @@ import zope.formlib.form
 class Base(object):
 
     form_fields = zope.formlib.form.FormFields(
-        zeit.cms.testcontenttype.interfaces.ITestContentType).omit('xml')
+        zeit.cms.testcontenttype.interfaces.IExampleContentType).omit('xml')
 
 
 class Edit(Base, zeit.cms.content.browser.form.CommonMetadataEditForm):

--- a/src/zeit/cms/testcontenttype/configure.zcml
+++ b/src/zeit/cms/testcontenttype/configure.zcml
@@ -8,21 +8,21 @@
 
   <include package=".browser" />
 
-  <class class=".testcontenttype.TestContentType">
+  <class class=".testcontenttype.ExampleContentType">
     <implements interface="zope.annotation.interfaces.IAttributeAnnotatable" />
     <implements interface="zeit.cms.content.interfaces.IDAVPropertiesInXML" />
     <require
-      interface=".interfaces.ITestContentType"
+      interface=".interfaces.IExampleContentType"
       permission="zope.View"
       />
     <require
-      set_schema=".interfaces.ITestContentType"
+      set_schema=".interfaces.IExampleContentType"
       permission="zeit.EditContent"
       />
   </class>
 
   <interface
-    interface=".interfaces.ITestContentType"
+    interface=".interfaces.IExampleContentType"
     type="zeit.cms.interfaces.ICMSContentType"
     />
 

--- a/src/zeit/cms/testcontenttype/interfaces.py
+++ b/src/zeit/cms/testcontenttype/interfaces.py
@@ -3,7 +3,7 @@ import zeit.cms.content.interfaces
 import zeit.cms.tagging.interfaces
 
 
-class ITestContentType(
+class IExampleContentType(
     zeit.cms.content.interfaces.ICommonMetadata,
     zeit.cms.content.interfaces.IXMLContent):
     """A type for testing."""
@@ -13,6 +13,6 @@ class ITestContentType(
         default=())
 
 
-ITestContentType.setTaggedValue('zeit.cms.type', 'testcontenttype')
-ITestContentType.setTaggedValue(
+IExampleContentType.setTaggedValue('zeit.cms.type', 'testcontenttype')
+IExampleContentType.setTaggedValue(
     'zeit.cms.addform', 'zeit.cms.testcontenttype.Add')

--- a/src/zeit/cms/testcontenttype/testcontenttype.py
+++ b/src/zeit/cms/testcontenttype/testcontenttype.py
@@ -6,11 +6,11 @@ import zeit.cms.type
 import zope.interface
 
 
-class TestContentType(zeit.cms.content.metadata.CommonMetadata):
+class ExampleContentType(zeit.cms.content.metadata.CommonMetadata):
     """A type for testing."""
 
     zope.interface.implements(
-        zeit.cms.testcontenttype.interfaces.ITestContentType,
+        zeit.cms.testcontenttype.interfaces.IExampleContentType,
         zeit.cms.interfaces.IEditorialContent)
 
     default_template = (
@@ -18,9 +18,9 @@ class TestContentType(zeit.cms.content.metadata.CommonMetadata):
         '<head/><body/></testtype>')
 
 
-class TestContentTypeType(zeit.cms.type.XMLContentTypeDeclaration):
+class ExampleContentTypeType(zeit.cms.type.XMLContentTypeDeclaration):
 
-    factory = TestContentType
-    interface = zeit.cms.testcontenttype.interfaces.ITestContentType
+    factory = ExampleContentType
+    interface = zeit.cms.testcontenttype.interfaces.IExampleContentType
     type = 'testcontenttype'
     register_as_type = False

--- a/src/zeit/cms/testing.py
+++ b/src/zeit/cms/testing.py
@@ -18,7 +18,6 @@ import pytest
 import random
 import re
 import socket
-import string
 import sys
 import threading
 import time

--- a/src/zeit/cms/testing.py
+++ b/src/zeit/cms/testing.py
@@ -14,6 +14,7 @@ import logging
 import os
 import pkg_resources
 import plone.testing
+import pytest
 import random
 import re
 import socket
@@ -347,6 +348,7 @@ gocept.selenium.webdriver.WebdriverSeleneseLayer.tearDown = (
     selenium_teardown_authcache)
 
 
+@pytest.mark.slow
 class SeleniumTestCase(gocept.selenium.WebdriverSeleneseTestCase,
                        FunctionalTestCase):
 

--- a/src/zeit/cms/workflow/mock.txt
+++ b/src/zeit/cms/workflow/mock.txt
@@ -35,7 +35,7 @@ Register event handlers to make sure the proper events are sent out:
 Let's try this on a testcontent:
 
 >>> import zeit.cms.testcontenttype.testcontenttype
->>> content = zeit.cms.testcontenttype.testcontenttype.TestContentType()
+>>> content = zeit.cms.testcontenttype.testcontenttype.ExampleContentType()
 >>> content.uniqueId = 'http://xml.zeit.de/testcontent'
 >>> workflow = zeit.cms.workflow.interfaces.IPublish(content)
 >>> info = zeit.cms.workflow.interfaces.IPublishInfo(content)

--- a/src/zeit/cms/workflow/modified.txt
+++ b/src/zeit/cms/workflow/modified.txt
@@ -19,7 +19,7 @@ Checkout and checkin again:
 >>> checked_out = manager.checkout()
 >>> manager = zeit.cms.checkout.interfaces.ICheckinManager(checked_out)
 >>> manager.checkin()
-<zeit.cms.testcontenttype.testcontenttype.TestContentType...>
+<zeit.cms.testcontenttype.testcontenttype.ExampleContentType...>
 
 The last modifier is zope.user now:
 

--- a/src/zeit/ghost/tests/test_ghost.py
+++ b/src/zeit/ghost/tests/test_ghost.py
@@ -1,6 +1,6 @@
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.checkout.interfaces import ICheckoutManager
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 import mock
 import zeit.cms.checkout.interfaces
 import zeit.cms.testing
@@ -13,7 +13,7 @@ class GhostbusterTest(zeit.cms.testing.FunctionalTestCase):
     layer = zeit.ghost.testing.ZCML_LAYER
 
     def test_removes_excessive_ghosts_on_checkout(self):
-        self.repository['ghost-origin'] = TestContentType()
+        self.repository['ghost-origin'] = ExampleContentType()
         wc = zeit.cms.checkout.interfaces.IWorkingcopy(None)
         for i in range(zeit.ghost.ghost.TARGET_WORKINGCOPY_SIZE * 2):
             with mock.patch('zeit.ghost.ghost._remove_excessive_ghosts'):
@@ -35,7 +35,7 @@ class GhostbusterTest(zeit.cms.testing.FunctionalTestCase):
         wc = zeit.cms.checkout.interfaces.IWorkingcopy(None)
         for i in range(zeit.ghost.ghost.TARGET_WORKINGCOPY_SIZE):
             name = 'test-%s' % i
-            self.repository[name] = TestContentType()
+            self.repository[name] = ExampleContentType()
             ICheckoutManager(self.repository[name]).checkout()
 
         zeit.ghost.ghost.create_ghost(self.repository['testcontent'])

--- a/src/zeit/workflow/README.txt
+++ b/src/zeit/workflow/README.txt
@@ -347,7 +347,7 @@ xml.
 >>> import zeit.workflow.interfaces
 >>> article = repository['testcontent']
 >>> article
-<zeit.cms.testcontenttype.testcontenttype.TestContentType...>
+<zeit.cms.testcontenttype.testcontenttype.ExampleContentType...>
 >>> workflow = zeit.workflow.interfaces.IContentWorkflow(article)
 >>> workflow.date_first_released is None
 True

--- a/src/zeit/workflow/browser/indicator.txt
+++ b/src/zeit/workflow/browser/indicator.txt
@@ -48,9 +48,9 @@ Make the test content type an asset to test the workflow:
 >>> import zeit.cms.interfaces
 >>> import zeit.cms.testcontenttype.testcontenttype
 >>> old_implements = list(zope.interface.implementedBy(
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType))
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType))
 >>> zope.interface.classImplementsOnly(
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType,
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType,
 ...     zeit.cms.interfaces.IAsset)
 >>> content = repository['testcontent']
 
@@ -72,7 +72,7 @@ u''
 Reset the implements:
 
 >>> zope.interface.classImplementsOnly(
-...     zeit.cms.testcontenttype.testcontenttype.TestContentType,
+...     zeit.cms.testcontenttype.testcontenttype.ExampleContentType,
 ...     *old_implements)
 
 Clean up:

--- a/src/zeit/workflow/browser/tests/test_publish.py
+++ b/src/zeit/workflow/browser/tests/test_publish.py
@@ -80,10 +80,10 @@ class TestPublish(
 
     def test_opening_dialog_from_folder_view_points_to_content(self):
         # Regression VIV-452
-        from zeit.cms.testcontenttype.testcontenttype import TestContentType
+        from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
         from zeit.cms.workflow.interfaces import IPublish, IPublishInfo
         zope.component.hooks.setSite(self.getRootFolder())
-        self.repository['other'] = TestContentType()
+        self.repository['other'] = ExampleContentType()
         self.prepare_content('http://xml.zeit.de/other')
         self.prepare_content('http://xml.zeit.de/testcontent')
         IPublish(self.repository['other']).publish()

--- a/src/zeit/workflow/testing.py
+++ b/src/zeit/workflow/testing.py
@@ -154,14 +154,14 @@ class FakeValidatingWorkflow(zeit.workflow.publishinfo.PublishInfo):
         return self._can_publish
 
 
-@zope.component.adapter(zeit.cms.testcontenttype.interfaces.ITestContentType)
+@zope.component.adapter(zeit.cms.testcontenttype.interfaces.IExampleContentType)
 @zope.interface.implementer(zeit.cms.workflow.interfaces.IPublishInfo)
 def workflow_with_error_for_testcontent(context):
     return FakeValidatingWorkflow(
         context, 'Fake Validation Error Message', CAN_PUBLISH_ERROR)
 
 
-@zope.component.adapter(zeit.cms.testcontenttype.interfaces.ITestContentType)
+@zope.component.adapter(zeit.cms.testcontenttype.interfaces.IExampleContentType)
 @zope.interface.implementer(zeit.cms.workflow.interfaces.IPublishInfo)
 def workflow_with_warning_for_testcontent(context):
     return FakeValidatingWorkflow(

--- a/src/zeit/workflow/tests/test_publish.py
+++ b/src/zeit/workflow/tests/test_publish.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from zeit.cms.checkout.helper import checked_out
 from zeit.cms.interfaces import ICMSContent
 from zeit.cms.related.interfaces import IRelatedContent
-from zeit.cms.testcontenttype.testcontenttype import TestContentType
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 from zeit.cms.workflow.interfaces import IPublishInfo, IPublish
 import gocept.testing.mock
 import mock
@@ -118,7 +118,7 @@ class PublicationDependencies(zeit.cms.testing.FunctionalTestCase):
     def populate_repository_with_dummy_content(self):
         self.related = []
         for i in range(3):
-            item = TestContentType()
+            item = ExampleContentType()
             self.repository['t%s' % i] = item
             self.related.append(self.repository['t%s' % i])
 


### PR DESCRIPTION
Plus some other py.test related fixes.