### PR TITLE
ZON-3475: Make checkout lock timeout configurable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,11 @@
 zeit.cms changes
 ================
 
-2.96.7 (unreleased)
+2.97.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-3475: Make checkout lock timeout configurable
+  product-config ``zeit.cms:checkout-lock-timeout[-temporary]``
 
 
 2.96.6 (2017-03-20)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.cms',
-    version='2.96.7.dev0',
+    version='2.97.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/cms/checkout/manager.py
+++ b/src/zeit/cms/checkout/manager.py
@@ -61,8 +61,12 @@ class CheckoutManager(object):
     def checkout(self, event=True, temporary=False, publishing=False):
         self._guard_checkout()
         lockable = zope.app.locking.interfaces.ILockable(self.context, None)
+        config = zope.app.appsetup.product.getProductConfiguration('zeit.cms')
         if lockable is not None and not lockable.locked():
-            timeout = 30 if temporary else 3600
+            timeout = 'checkout-lock-timeout'
+            if temporary:
+                timeout += '-temporary'
+            timeout = int(config[timeout])
             try:
                 lockable.lock(timeout=timeout)
             except zope.app.locking.interfaces.LockingError, e:

--- a/src/zeit/cms/testing.py
+++ b/src/zeit/cms/testing.py
@@ -201,6 +201,9 @@ cms_product_config = """\
   source-storystreams file://{base}/content/storystreams.xml
   source-printressorts file://{base}/content/print-ressorts.xml
 
+  checkout-lock-timeout 3600
+  checkout-lock-timeout-temporary 30
+
   preview-prefix http://localhost/preview-prefix
   live-prefix http://localhost/live-prefix
   friebert-wc-preview-prefix /wcpreview


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/vivi-deployment/pull/25