### PR TITLE
ZON-3942: Create retract jobs after publishing imported objects that only have `released_to` set

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,12 @@ zeit.cms changes
 - BUG-562: RelatedBase must use XML-Persistent, so changes are stored
   properly on commit
 
+- BUG-301: Cancel scheduled publish jobs when timestamps are changed,
+  regardless of while checked-out or checked-in
+
+- ZON-3942: Create retract jobs after publishing imported objects that
+  only have `released_to` set
+
 
 2.97.5 (2017-05-11)
 -------------------

--- a/src/zeit/workflow/README.txt
+++ b/src/zeit/workflow/README.txt
@@ -313,19 +313,19 @@ The actions are logged:
 http://xml.zeit.de/online/2007/01/studiVZ
      Urgent: yes
 http://xml.zeit.de/online/2007/01/studiVZ
-     To be published on 2008 6 13  07:38:48  (job #...)
+     To publish on 2008 6 13  07:38:48  (job #...)
 http://xml.zeit.de/online/2007/01/studiVZ
-     Scheduled publication cancelled (job #...).
+     Scheduled publish cancelled (job #...).
 http://xml.zeit.de/online/2007/01/studiVZ
-     To be published on 2008 6 13  07:38:49  (job #...)
-http://xml.zeit.de/online/2007/01/studiVZ
-     Published
-http://xml.zeit.de/online/2007/01/studiVZ
-     To be published on 2000 2 3  01:00:00  (job #...)
+     To publish on 2008 6 13  07:38:49  (job #...)
 http://xml.zeit.de/online/2007/01/studiVZ
      Published
 http://xml.zeit.de/online/2007/01/studiVZ
-     To be retracted on 2008 6 13  07:38:50  (job #...)
+     To publish on 2000 2 3  01:00:00  (job #...)
+http://xml.zeit.de/online/2007/01/studiVZ
+     Published
+http://xml.zeit.de/online/2007/01/studiVZ
+     To retract on 2008 6 13  07:38:50  (job #...)
 http://xml.zeit.de/online/2007/01/studiVZ
      Retracted
 

--- a/src/zeit/workflow/tests/test_timebased.py
+++ b/src/zeit/workflow/tests/test_timebased.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from zeit.cms.checkout.helper import checked_out
 import lovely.remotetask.interfaces
+import mock
 import pytz
 import zeit.cms.testing
 import zeit.workflow.testing
@@ -49,3 +50,53 @@ class TimeBasedWorkflowTest(zeit.cms.testing.FunctionalTestCase):
         self.assertNotEqual(job1, job2)
         self.assertEqual('cancelled', tasks.getStatus(job1))
         self.assertEqual('delayed', tasks.getStatus(job2))
+
+
+class PrintImportSchedulingTest(zeit.cms.testing.FunctionalTestCase):
+
+    layer = zeit.workflow.testing.LAYER
+
+    def test_should_schedule_job_when_no_jobid_present(self):
+        content = self.repository['testcontent']
+        workflow = zeit.cms.workflow.interfaces.IPublishInfo(content)
+        workflow.released_to = datetime.now(pytz.UTC) + timedelta(days=1)
+        self.assertEqual(None, workflow.retract_job_id)
+        workflow.urgent = True
+        zeit.cms.workflow.interfaces.IPublish(content).publish()
+        zeit.workflow.testing.run_publish()
+        self.assertNotEqual(None, workflow.retract_job_id)
+
+    def test_jobid_present_should_do_nothing(self):
+        content = self.repository['testcontent']
+        workflow = zeit.cms.workflow.interfaces.IPublishInfo(content)
+        workflow.release_period = (
+            None, datetime.now(pytz.UTC) + timedelta(days=1))
+        self.assertNotEqual(None, workflow.retract_job_id)
+        workflow.urgent = True
+        zeit.cms.workflow.interfaces.IPublish(content).publish()
+        with mock.patch('zeit.workflow.timebased.'
+                        'TimeBasedWorkflow.setup_job') as setup_job:
+            zeit.workflow.testing.run_publish()
+            self.assertFalse(setup_job.called)
+
+    def test_no_retract_time_present_should_do_nothing(self):
+        content = self.repository['testcontent']
+        workflow = zeit.cms.workflow.interfaces.IPublishInfo(content)
+        workflow.urgent = True
+        zeit.cms.workflow.interfaces.IPublish(content).publish()
+        with mock.patch('zeit.workflow.timebased.'
+                        'TimeBasedWorkflow.setup_job') as setup_job:
+            zeit.workflow.testing.run_publish()
+            self.assertFalse(setup_job.called)
+
+    def test_retract_time_in_the_past_should_not_schedule_again(self):
+        content = self.repository['testcontent']
+        workflow = zeit.cms.workflow.interfaces.IPublishInfo(content)
+        workflow.release_period = (
+            None, datetime.now(pytz.UTC) + timedelta(days=-1))
+        workflow.urgent = True
+        zeit.cms.workflow.interfaces.IPublish(content).publish()
+        with mock.patch('zeit.workflow.timebased.'
+                        'TimeBasedWorkflow.setup_job') as setup_job:
+            zeit.workflow.testing.run_publish()
+            self.assertFalse(setup_job.called)

--- a/src/zeit/workflow/tests/test_timebased.py
+++ b/src/zeit/workflow/tests/test_timebased.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timedelta
+import lovely.remotetask.interfaces
+import pytz
+import zeit.cms.testing
+import zeit.workflow.testing
+import zope.component
+
+
+class TimeBasedWorkflowTest(zeit.cms.testing.FunctionalTestCase):
+
+    layer = zeit.workflow.testing.LAYER
+
+    def test_removing_release_period_should_remove_jobid(self):
+        content = self.repository['testcontent']
+        workflow = zeit.workflow.interfaces.IContentWorkflow(content)
+        workflow.release_period = (
+            datetime.now(pytz.UTC) + timedelta(days=1), None)
+        self.assertNotEqual(None, workflow.publish_job_id)
+        # Put job into "delayed" state, otherwise it won't cancel.
+        tasks = zope.component.getUtility(
+            lovely.remotetask.interfaces.ITaskService, 'general')
+        tasks.process()
+        workflow.release_period = (None, None)
+        self.assertEqual(None, workflow.publish_job_id)

--- a/src/zeit/workflow/tests/test_timebased.py
+++ b/src/zeit/workflow/tests/test_timebased.py
@@ -13,7 +13,7 @@ class TimeBasedWorkflowTest(zeit.cms.testing.FunctionalTestCase):
 
     def test_removing_release_period_should_remove_jobid(self):
         content = self.repository['testcontent']
-        workflow = zeit.workflow.interfaces.IContentWorkflow(content)
+        workflow = zeit.cms.workflow.interfaces.IPublishInfo(content)
         workflow.release_period = (
             datetime.now(pytz.UTC) + timedelta(days=1), None)
         self.assertNotEqual(None, workflow.publish_job_id)
@@ -26,9 +26,9 @@ class TimeBasedWorkflowTest(zeit.cms.testing.FunctionalTestCase):
 
     def test_should_cancel_job_when_changed_during_checkout(self):
         content = self.repository['testcontent']
-        workflow = zeit.workflow.interfaces.IContentWorkflow(content)
+        workflow = zeit.cms.workflow.interfaces.IPublishInfo(content)
         with checked_out(content) as co:
-            workflow = zeit.workflow.interfaces.IContentWorkflow(co)
+            workflow = zeit.cms.workflow.interfaces.IPublishInfo(co)
             workflow.release_period = (
                 datetime.now(pytz.UTC) + timedelta(days=1), None)
         # Put job into "delayed" state, otherwise it won't cancel.
@@ -40,7 +40,7 @@ class TimeBasedWorkflowTest(zeit.cms.testing.FunctionalTestCase):
         self.assertEqual('delayed', tasks.getStatus(job1))
 
         with checked_out(content) as co:
-            workflow = zeit.workflow.interfaces.IContentWorkflow(co)
+            workflow = zeit.cms.workflow.interfaces.IPublishInfo(co)
             workflow.release_period = (
                 datetime.now(pytz.UTC) + timedelta(days=2), None)
         tasks.process()

--- a/src/zeit/workflow/tests/test_timebased.py
+++ b/src/zeit/workflow/tests/test_timebased.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from zeit.cms.checkout.helper import checked_out
 import lovely.remotetask.interfaces
 import pytz
 import zeit.cms.testing
@@ -22,3 +23,29 @@ class TimeBasedWorkflowTest(zeit.cms.testing.FunctionalTestCase):
         tasks.process()
         workflow.release_period = (None, None)
         self.assertEqual(None, workflow.publish_job_id)
+
+    def test_should_cancel_job_when_changed_during_checkout(self):
+        content = self.repository['testcontent']
+        workflow = zeit.workflow.interfaces.IContentWorkflow(content)
+        with checked_out(content) as co:
+            workflow = zeit.workflow.interfaces.IContentWorkflow(co)
+            workflow.release_period = (
+                datetime.now(pytz.UTC) + timedelta(days=1), None)
+        # Put job into "delayed" state, otherwise it won't cancel.
+        tasks = zope.component.getUtility(
+            lovely.remotetask.interfaces.ITaskService, 'general')
+        tasks.process()
+        job1 = workflow.publish_job_id
+        self.assertNotEqual(None, job1)
+        self.assertEqual('delayed', tasks.getStatus(job1))
+
+        with checked_out(content) as co:
+            workflow = zeit.workflow.interfaces.IContentWorkflow(co)
+            workflow.release_period = (
+                datetime.now(pytz.UTC) + timedelta(days=2), None)
+        tasks.process()
+        job2 = workflow.publish_job_id
+        self.assertNotEqual(None, job2)
+        self.assertNotEqual(job1, job2)
+        self.assertEqual('cancelled', tasks.getStatus(job1))
+        self.assertEqual('delayed', tasks.getStatus(job2))

--- a/src/zeit/workflow/timebased.py
+++ b/src/zeit/workflow/timebased.py
@@ -67,6 +67,7 @@ class TimeBasedWorkflow(zeit.workflow.publishinfo.PublishInfo):
                 'timebased-%s-cancel' % taskname,
                 default='Scheduled %s cancelled (job #${job}).' % taskname,
                 mapping={'job': jobid()}))
+            setattr(self, '%s_job_id' % taskname, None)
         if timestamp is not None:
             setattr(self, '%s_job_id' % taskname, self.add_job(
                 'zeit.workflow.%s' % taskname, timestamp))

--- a/src/zeit/workflow/timebased.py
+++ b/src/zeit/workflow/timebased.py
@@ -1,4 +1,4 @@
-from zeit.cms.content.interfaces import WRITEABLE_LIVE, WRITEABLE_ALWAYS
+from zeit.cms.content.interfaces import WRITEABLE_ALWAYS
 from zeit.cms.i18n import MessageFactory as _
 from zeit.cms.workflow.interfaces import PRIORITY_DEFAULT
 import datetime
@@ -33,10 +33,10 @@ class TimeBasedWorkflow(zeit.workflow.publishinfo.PublishInfo):
 
     publish_job_id = zeit.cms.content.dav.DAVProperty(
         zope.schema.Int(), WORKFLOW_NS, 'publish_job_id',
-        writeable=WRITEABLE_LIVE)
+        writeable=WRITEABLE_ALWAYS)
     retract_job_id = zeit.cms.content.dav.DAVProperty(
         zope.schema.Int(), WORKFLOW_NS, 'retract_job_id',
-        writeable=WRITEABLE_LIVE)
+        writeable=WRITEABLE_ALWAYS)
 
     def __init__(self, context):
         self.context = self.__parent__ = context


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/zeit.locales/pull/22

Enthält auch noch BUG-301, ich dachte erst das würde sich durch die Implementierung hier mit ergeben, tat's dann aber doch nicht, und dann wollte ich es nicht mehr umständlich auseinanderbasteln. Am besten daher commitweise anschauen.