### PR TITLE
BUG-500: Implement determining a separate set of dependencies that we apply on retract

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,12 +1,14 @@
 zeit.cms changes
 ================
 
-2.105.2 (unreleased)
+2.106.0 (unreleased)
 --------------------
 
 - BUG-345: Delete objectlog entries on delete and move
 
 - BUG-345: Only reset actual publishinfo properties on copy
+
+- BUG-500: Add `retract_dependencies` flag to `IPublicationDependencies`
 
 
 2.105.1 (2017-07-13)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.cms',
-    version='2.105.2.dev0',
+    version='2.106.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/workflow/README.txt
+++ b/src/zeit/workflow/README.txt
@@ -790,6 +790,35 @@ http://xml.zeit.de/politik.feed
     ...     (zeit.cms.workflow.interfaces.IWithMasterObjectEvent,))
 
 
+Dependend retract
++++++++++++++++++
+
+Retract does *not* honours dependencies:
+
+>>> logfile.seek(0)
+>>> logfile.truncate()
+>>> job_id = publish.retract()
+>>> tasks.process()
+BeforeRetractEvent
+    Object: http://xml.zeit.de/online/2007/01/Somalia
+    Master: http://xml.zeit.de/online/2007/01/Somalia
+RetractedEvent
+    Object: http://xml.zeit.de/online/2007/01/Somalia
+    Master: http://xml.zeit.de/online/2007/01/Somalia
+>>> feed_workflow.published
+True
+
+Make sure the file would actually have been removed:
+
+>>> print logfile.getvalue(),
+Running job ...
+Retracting http://xml.zeit.de/online/2007/01/Somalia
+...retract.sh:
+Retracting test script
+work/online/2007/01/Somalia
+done.
+...
+
 
 Recursive dependencies
 ++++++++++++++++++++++
@@ -836,35 +865,6 @@ http://xml.zeit.de/politik.feed
      Published
 http://xml.zeit.de/politik.feed
      Published
-
-Dependend retract
-+++++++++++++++++
-
-Retract does *not* honours dependencies:
-
->>> logfile.seek(0)
->>> logfile.truncate()
->>> job_id = publish.retract()
->>> tasks.process()
-BeforeRetractEvent
-    Object: http://xml.zeit.de/online/2007/01/Somalia
-    Master: http://xml.zeit.de/online/2007/01/Somalia
-RetractedEvent
-    Object: http://xml.zeit.de/online/2007/01/Somalia
-    Master: http://xml.zeit.de/online/2007/01/Somalia
->>> feed_workflow.published
-True
-
-Make sure the file would actually have been removed:
-
->>> print logfile.getvalue(),
-Running job ...
-Retracting http://xml.zeit.de/online/2007/01/Somalia
-...retract.sh:
-Retracting test script
-work/online/2007/01/Somalia
-done.
-...
 
 >>> gsm.unregisterHandler(pr_handler,
 ...     (zeit.cms.workflow.interfaces.IWithMasterObjectEvent,))

--- a/src/zeit/workflow/README.txt
+++ b/src/zeit/workflow/README.txt
@@ -709,9 +709,7 @@ Simple dependencies
 Let's assume the Somalia article has a dependency on the politik.feed. This
 is done via a named adapter to IPublicationDependencies:
 
->>> class SomaliaFeed(object):
-...     def __init__(self, context):
-...         self.context = context
+>>> class SomaliaFeed(zeit.workflow.dependency.DependencyBase):
 ...     def get_dependencies(self):
 ...         if self.context.uniqueId.endswith('Somalia'):
 ...             return (repository['politik.feed'],)
@@ -793,7 +791,7 @@ http://xml.zeit.de/politik.feed
 Dependend retract
 +++++++++++++++++
 
-Retract does *not* honours dependencies:
+Retract does *not* honour dependencies by default:
 
 >>> logfile.seek(0)
 >>> logfile.truncate()
@@ -819,6 +817,28 @@ work/online/2007/01/Somalia
 done.
 ...
 
+If the dependencies adapter allows it, the dependencies are retracted as well:
+
+>>> SomaliaFeed.retract_dependencies = True
+>>> logfile.seek(0)
+>>> logfile.truncate()
+>>> job_id = publish.retract()
+>>> tasks.process()
+BeforeRetractEvent
+    Object: http://xml.zeit.de/online/2007/01/Somalia
+    Master: http://xml.zeit.de/online/2007/01/Somalia
+BeforeRetractEvent
+    Object: http://xml.zeit.de/politik.feed
+    Master: http://xml.zeit.de/online/2007/01/Somalia
+RetractedEvent
+    Object: http://xml.zeit.de/online/2007/01/Somalia
+    Master: http://xml.zeit.de/online/2007/01/Somalia
+RetractedEvent
+    Object: http://xml.zeit.de/politik.feed
+    Master: http://xml.zeit.de/online/2007/01/Somalia
+>>> feed_workflow.published
+False
+
 
 Recursive dependencies
 ++++++++++++++++++++++
@@ -828,9 +848,7 @@ published when either is published.
 
 Add the reverse dependency:
 
->>> class FeedSomalia(object):
-...     def __init__(self, context):
-...         self.context = context
+>>> class FeedSomalia(zeit.workflow.dependency.DependencyBase):
 ...     def get_dependencies(self):
 ...         if self.context == feed:
 ...             return (somalia,)
@@ -864,13 +882,13 @@ PublishedEvent
 http://xml.zeit.de/politik.feed
      Published
 http://xml.zeit.de/politik.feed
+     Retracted
+http://xml.zeit.de/politik.feed
      Published
 
 >>> gsm.unregisterHandler(pr_handler,
 ...     (zeit.cms.workflow.interfaces.IWithMasterObjectEvent,))
 True
-
-
 
 Depending on non workflowed objects
 +++++++++++++++++++++++++++++++++++
@@ -880,9 +898,7 @@ will be published nevertheles.
 
 Let somalia also depend on the /2007 folder:
 
->>> class SomaliaFolder(object):
-...     def __init__(self, context):
-...         self.context = context
+>>> class SomaliaFolder(zeit.workflow.dependency.DependencyBase):
 ...     def get_dependencies(self):
 ...         if self.context.uniqueId.endswith('Somalia'):
 ...             return (repository['2007'],)

--- a/src/zeit/workflow/configure.zcml
+++ b/src/zeit/workflow/configure.zcml
@@ -71,8 +71,4 @@
   <subscriber handler=".oldstatus.set_status" />
   <subscriber handler=".oldstatus.remove_status" />
 
-
-  <!-- dependencies -->
-  <adapter factory=".dependency.Dependencies" />
-
 </configure>

--- a/src/zeit/workflow/dependency.py
+++ b/src/zeit/workflow/dependency.py
@@ -1,18 +1,14 @@
+import grokcore.component as grok
 import zeit.cms.interfaces
 import zeit.workflow.interfaces
 import zope.component
-import zope.interface
 
 
-class Dependencies(object):
+class Dependencies(grok.Adapter):
     """Adapter to find the publication dependencies of an object."""
 
-    zope.component.adapts(zeit.cms.interfaces.ICMSContent)
-    zope.interface.implements(
-        zeit.workflow.interfaces.IPublicationDependencies)
-
-    def __init__(self, context):
-        self.context = context
+    grok.context(zeit.cms.interfaces.ICMSContent)
+    grok.implements(zeit.workflow.interfaces.IPublicationDependencies)
 
     def get_dependencies(self):
         dependencies = set()

--- a/src/zeit/workflow/dependency.py
+++ b/src/zeit/workflow/dependency.py
@@ -12,11 +12,34 @@ class Dependencies(grok.Adapter):
 
     def get_dependencies(self):
         dependencies = set()
-        for name, this_deps in zope.component.getAdapters(
+        for adapter in self._find_adapters():
+            dependencies.update(adapter.get_dependencies())
+        return sorted(dependencies, key=lambda x: x.uniqueId)
+
+    def get_retract_dependencies(self):
+        dependencies = set()
+        for adapter in self._find_adapters():
+            if adapter.retract_dependencies:
+                dependencies.update(adapter.get_dependencies())
+        return sorted(dependencies, key=lambda x: x.uniqueId)
+
+    def _find_adapters(self):
+        for name, adapter in zope.component.getAdapters(
                 (self.context,),
                 zeit.workflow.interfaces.IPublicationDependencies):
             if not name:
                 # This is actually this adapter
                 continue
-            dependencies.update(this_deps.get_dependencies())
-        return sorted(dependencies, key=lambda x: x.uniqueId)
+            yield adapter
+
+
+class DependencyBase(grok.Adapter):
+
+    grok.implements(zeit.workflow.interfaces.IPublicationDependencies)
+    grok.name('must be set in subclass')
+    grok.baseclass()
+
+    retract_dependencies = False
+
+    def get_dependencies(self):
+        return ()

--- a/src/zeit/workflow/interfaces.py
+++ b/src/zeit/workflow/interfaces.py
@@ -103,5 +103,9 @@ class IPublicationDependencies(zope.interface.Interface):
 
     The sequence contains all objects which need to be published along with the
     adapted object. Dependent containers will be published recursively.
-
     """
+
+    retract_dependencies = zope.interface.Attribute("""\
+        If True, retract dependent objects along with the adapted object.
+        Usually we cannot know whether an object is used by someone else and
+        thus can't retract it, but in some cases this decision can be made.""")


### PR DESCRIPTION
Benötigt alle anderen BUG-500 PRs, die API-Änderung ist nicht abwärtskompatibel