### PR TITLE
MAINT: Allow changing date_first_released in admin tab

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.cms changes
 2.104.3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- MAINT: Allow changing date_first_released in admin tab
 
 
 2.104.2 (2017-07-07)

--- a/src/zeit/cms/admin/browser/tests/test_admin.py
+++ b/src/zeit/cms/admin/browser/tests/test_admin.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+import pytz
 import zeit.cms.testing
+import zeit.cms.workflow.interfaces
 
 
 class TestAdminMenu(zeit.cms.testing.ZeitCmsBrowserTestCase):
@@ -26,3 +29,20 @@ class TestAdminMenu(zeit.cms.testing.ZeitCmsBrowserTestCase):
             'http://localhost:8080/++skin++vivi/repository/testcontent')
         self.browser.getLink('Checkout').click()
         self.assertIn('Admin CO', self.browser.contents)
+
+    def test_change_dates(self):
+        b = self.browser
+        b.open('http://localhost/++skin++vivi'
+               '/repository/testcontent/@@admin.html')
+        b.getControl('Adjust last published').value = '2001-01-07 11:22:33'
+        b.getControl('Adjust first released').value = '2001-01-08 11:22:33'
+        b.getControl('Apply').click()
+        with zeit.cms.testing.site(self.getRootFolder()):
+            content = self.repository['testcontent']
+            publish = zeit.cms.workflow.interfaces.IPublishInfo(content)
+            self.assertEqual(
+                datetime(2001, 1, 7, 10, 22, 33, tzinfo=pytz.UTC),
+                publish.date_last_published_semantic)
+            self.assertEqual(
+                datetime(2001, 1, 8, 10, 22, 33, tzinfo=pytz.UTC),
+                publish.date_first_released)

--- a/src/zeit/cms/admin/interfaces.py
+++ b/src/zeit/cms/admin/interfaces.py
@@ -18,3 +18,8 @@ class IAdjustSemanticPublish(zope.interface.Interface):
         title=_('Adjust last published with semantic change'),
         required=False,
         max=zeit.cms.interfaces.MAX_PUBLISH_DATE)
+
+    adjust_first_released = zope.schema.Datetime(
+        title=_('Adjust first released'),
+        required=False,
+        max=zeit.cms.interfaces.MAX_PUBLISH_DATE)

--- a/src/zeit/cms/admin/semantic.py
+++ b/src/zeit/cms/admin/semantic.py
@@ -16,8 +16,8 @@ class AdjustSemanticPublish(object):
 
     @property
     def adjust_semantic_publish(self):
-        return zeit.cms.workflow.interfaces.IPublishInfo(
-            self.context).date_last_published_semantic
+        publish = zeit.cms.workflow.interfaces.IPublishInfo(self.context)
+        return publish.date_last_published_semantic
 
     @adjust_semantic_publish.setter
     def adjust_semantic_publish(self, datetime):
@@ -25,12 +25,21 @@ class AdjustSemanticPublish(object):
         # date_last_published_semantic are defined as readonly.
         context = zope.security.proxy.removeSecurityProxy(self.context)
 
-        # Adjust date of last semantic publish
-        publish_info = zeit.cms.workflow.interfaces.IPublishInfo(context)
-        publish_info.date_last_published_semantic = datetime
-
+        publish = zeit.cms.workflow.interfaces.IPublishInfo(context)
+        publish.date_last_published_semantic = datetime
         # Also adjust state & date of last semantic change, to avoid setting
         # date_last_published_semantic during next publish of context
         semantic = zeit.cms.content.interfaces.ISemanticChange(context)
         semantic.has_semantic_change = False
         semantic.last_semantic_change = datetime
+
+    @property
+    def adjust_first_released(self):
+        publish = zeit.cms.workflow.interfaces.IPublishInfo(self.context)
+        return publish.date_first_released
+
+    @adjust_first_released.setter
+    def adjust_first_released(self, datetime):
+        context = zope.security.proxy.removeSecurityProxy(self.context)
+        publish = zeit.cms.workflow.interfaces.IPublishInfo(context)
+        publish.date_first_released = datetime

--- a/src/zeit/cms/admin/tests/test_semantic.py
+++ b/src/zeit/cms/admin/tests/test_semantic.py
@@ -44,3 +44,12 @@ class TestSemantic(zeit.cms.testing.ZeitCmsTestCase):
         self.assertEqual(
             False, zeit.cms.content.interfaces.ISemanticChange(
                 self.content).has_semantic_change)
+
+    def test_setting_adjust_first_released_overwrites_dfr(self):
+        lsc = datetime.datetime(2013, 10, 30, tzinfo=pytz.UTC)
+        semantic = IAdjustSemanticPublish(self.content)
+        semantic.adjust_first_released = lsc
+
+        self.assertEqual(
+            lsc, zeit.cms.workflow.interfaces.IPublishInfo(
+                self.content).date_first_released)

--- a/src/zeit/cms/workflow/mock.py
+++ b/src/zeit/cms/workflow/mock.py
@@ -55,7 +55,6 @@ class MockPublishInfo(object):
     zope.interface.implements(zeit.cms.workflow.interfaces.IPublishInfo)
 
     error_messages = ()
-    date_first_released = None
     date_print_published = None
     last_modified_by = u'testuser'
     last_published_by = u'testuser'
@@ -87,6 +86,14 @@ class MockPublishInfo(object):
     def date_last_published_semantic(self, value):
         _publish_times_semantic[self.context.uniqueId] = value
 
+    @property
+    def date_first_released(self):
+        return _publish_times_first.get(self.context.uniqueId)
+
+    @date_first_released.setter
+    def date_first_released(self, value):
+        _publish_times_first[self.context.uniqueId] = value
+
     def can_publish(self):
         return _can_publish.get(
             self.context.uniqueId,
@@ -102,6 +109,7 @@ _can_publish = {}
 _published = {}
 _publish_times = {}
 _publish_times_semantic = {}
+_publish_times_first = {}
 
 
 def reset():
@@ -109,4 +117,5 @@ def reset():
     _published.clear()
     _publish_times.clear()
     _publish_times_semantic.clear()
+    _publish_times_first.clear()
 zope.testing.cleanup.addCleanUp(reset)


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/zeit.locales/pull/26