### PR TITLE
ZON-4040: Add title to PrintRessortSource

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.cms changes
 ================
 
-2.102.1 (unreleased)
+2.103.0 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- ZON-4008: Add title to PrintRessortSource
 
 
 2.102.0 (2017-06-22)

--- a/src/zeit/cms/content/print-ressorts.xml
+++ b/src/zeit/cms/content/print-ressorts.xml
@@ -1,9 +1,9 @@
 <print-ressorts>
-  <ressort>Politik</ressort>
-  <ressort>Dossier</ressort>
-  <ressort>Wirtschaft</ressort>
-  <ressort>Wissen</ressort>
-  <ressort>Feuilleton</ressort>
-  <ressort>Entdecken</ressort>
-  <ressort>Chancen</ressort>
+  <ressort id="Politik">Politik</ressort>
+  <ressort id="Dossier">Dossier</ressort>
+  <ressort id="Wirtschaft">Wirtschaft</ressort>
+  <ressort id="Wissen">Wissen</ressort>
+  <ressort id="Feuilleton">Feuilleton</ressort>
+  <ressort id="Entdecken">Entdecken</ressort>
+  <ressort id="Chancen">Chanson</ressort>
 </print-ressorts>

--- a/src/zeit/cms/content/sources.py
+++ b/src/zeit/cms/content/sources.py
@@ -542,8 +542,11 @@ class AccessSource(XMLSource):
 ACCESS_SOURCE = AccessSource()
 
 
-class PrintRessortSource(SimpleXMLSource):
+class PrintRessortSource(XMLSource):
 
+    product_configuration = 'zeit.cms'
     config_url = 'source-printressorts'
+    attribute = 'id'
+
 
 PRINT_RESSORT_SOURCE = PrintRessortSource()

--- a/src/zeit/cms/content/tests/test_sources.py
+++ b/src/zeit/cms/content/tests/test_sources.py
@@ -113,3 +113,10 @@ class ProductSourceTest(zeit.cms.testing.ZeitCmsTestCase):
             if value.id == "BADDEPENDENCY":
                 self.assertEqual([], value.dependent_products)
                 break
+
+
+class PrintRessortTest(zeit.cms.testing.ZeitCmsTestCase):
+
+    def test_source_has_title(self):
+        source = zeit.cms.content.sources.PRINT_RESSORT_SOURCE
+        self.assertEqual("Chanson", source.factory.getTitle(None, 'Chancen'))


### PR DESCRIPTION
Die [printressort.xml ](http://cms-backend.staging.zeit.de:9000/cms/work/data/print-ressorts.xml) ist schon entsprechend angepasst. Bei einem Production Deployment muss dies entsprechend für die production config geschehen.