### PR TITLE
TMS-134: Resolve content without traversal if possible

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.cms changes
 ================
 
-3.1.5 (unreleased)
+3.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- TMS-134: Resolve content without traversal if possible
 
 
 3.1.4 (2017-11-01)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.cms',
-    version='3.1.5.dev0',
+    version='3.2.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/cms/content/xmlsupport.py
+++ b/src/zeit/cms/content/xmlsupport.py
@@ -11,8 +11,8 @@ import zeit.cms.checkout.interfaces
 import zeit.cms.content.interfaces
 import zeit.cms.content.lxmlpickle  # extended pickle support
 import zeit.cms.interfaces
+import zeit.cms.repository.repository
 import zeit.connector.interfaces
-import zope.container.contained
 import zope.interface
 import zope.security.interfaces
 import zope.security.proxy
@@ -33,30 +33,13 @@ class XMLRepresentationBase(object):
         self.xml = gocept.lxml.objectify.fromfile(xml_source)
 
 
-class XMLContentBase(XMLRepresentationBase,
-                     persistent.Persistent,
-                     zope.container.contained.Contained):
+class XMLContentBase(zeit.cms.repository.repository.ContentBase,
+                     XMLRepresentationBase,
+                     persistent.Persistent):
     """Base class for xml content."""
 
     zope.interface.implements(zeit.cms.content.interfaces.IXMLContent)
 
-    uniqueId = None
-    __name__ = None
-
-    def __cmp__(self, other):
-        if not zeit.cms.interfaces.ICMSContent.providedBy(other):
-            return -1
-        self_key = (self.uniqueId, self.__name__)
-        other_key = (other.uniqueId, other.__name__)
-        return cmp(self_key, other_key)
-
-    def __hash__(self):
-        return hash((self.uniqueId, self.__name__))
-
-    def __repr__(self):
-        return '<%s.%s %s>' % (
-            self.__class__.__module__, self.__class__.__name__,
-            self.uniqueId or '(unknown)')
 
 _default_marker = object()
 

--- a/src/zeit/cms/repository/README.txt
+++ b/src/zeit/cms/repository/README.txt
@@ -341,6 +341,8 @@ Let's clean that up again:
 True
 >>> del repository['online']['01']
 >>> del repository['online']['01-2']
+>>> import transaction
+>>> transaction.commit()
 
 Getting content by unique_id
 ============================

--- a/src/zeit/cms/repository/file.py
+++ b/src/zeit/cms/repository/file.py
@@ -1,19 +1,18 @@
-
 from zeit.cms.i18n import MessageFactory as _
 import ZODB.blob
 import persistent
 import zeit.cms.interfaces
 import zeit.cms.repository.interfaces
+import zeit.cms.repository.repository
 import zeit.cms.type
 import zeit.cms.workingcopy.interfaces
 import zeit.connector.interfaces
-import zope.app.container.contained
 import zope.component
 import zope.interface
 import zope.security.proxy
 
 
-class RepositoryFile(zope.app.container.contained.Contained):
+class RepositoryFile(zeit.cms.repository.repository.ContentBase):
     """A file in the repository."""
 
     zope.interface.implements(zeit.cms.repository.interfaces.IFile,

--- a/src/zeit/cms/repository/repository.py
+++ b/src/zeit/cms/repository/repository.py
@@ -35,12 +35,10 @@ class ContentBase(zope.container.contained.Contained):
     def __cmp__(self, other):
         if not zeit.cms.interfaces.ICMSContent.providedBy(other):
             return -1
-        self_key = (self.uniqueId, self.__name__)
-        other_key = (other.uniqueId, other.__name__)
-        return cmp(self_key, other_key)
+        return cmp(self.uniqueId, other.uniqueId)
 
     def __hash__(self):
-        return hash((self.uniqueId, self.__name__))
+        return hash(self.uniqueId)
 
     def __repr__(self):
         return '<%s.%s %s>' % (

--- a/src/zeit/cms/repository/repository.py
+++ b/src/zeit/cms/repository/repository.py
@@ -1,7 +1,9 @@
 from zeit.cms.i18n import MessageFactory as _
+from zeit.cms.repository.interfaces import IRepositoryContent
 import gocept.cache.property
 import grokcore.component
 import logging
+import os.path
 import persistent
 import re
 import zeit.cms.interfaces
@@ -44,6 +46,43 @@ class ContentBase(zope.container.contained.Contained):
         return '<%s.%s %s>' % (
             self.__class__.__module__, self.__class__.__name__,
             self.uniqueId or '(unknown)')
+
+    # Support the performance optimization in Repository.getContent()
+    # by optionally resolving our parent ourselves.
+    @property
+    def __parent__(self):
+        if hasattr(self, '__explicit_parent__'):
+            return self.__explicit_parent__
+        if not IRepositoryContent.providedBy(self):
+            # This most likely means we're somewhere inside a workingcopy. The
+            # default value in zope.container.Contained is None, and we also
+            # need to handle bw-compat for ILocalContent objects that existed
+            # before __explicit_parent__ was introduced.
+            return self.__dict__.get('__parent__')
+
+        unique_id = self.uniqueId
+        trailing_slash = unique_id.endswith('/')
+        if trailing_slash:
+            unique_id = unique_id[:-1]
+        parent_id = os.path.dirname(unique_id)
+        parent_id = parent_id.rstrip('/') + '/'
+
+        repository = zope.component.getUtility(
+            zeit.cms.repository.interfaces.IRepository)
+        # "root" edge case part 1a: We use the repository itself as the '/'
+        # folder, it serves as the traversal root for DAV content
+        if parent_id == repository.uniqueId:
+            return repository
+        return repository.getContent(parent_id)
+
+    @__parent__.setter
+    def __parent__(self, value):
+        self.__explicit_parent__ = value
+
+    @__parent__.deleter
+    def __parent__(self):
+        if hasattr(self, '__explicit_parent__'):
+            del self.__explicit_parent__
 
 
 class Container(ContentBase):
@@ -186,7 +225,12 @@ class Repository(persistent.Persistent, Container):
         zeit.cms.section.interfaces.IZONSection,
         zope.annotation.interfaces.IAttributeAnnotatable)
 
+    # "root" edge case part 2, allow the ZODB folder to set itself as the
+    # parent when installing the Repository object, since the DAV hierarchy
+    # ends there and changes over to the ZODB hierarchy.
+    __parent__ = None
     uniqueId = zeit.cms.interfaces.ID_NAMESPACE
+
     uncontained_content = gocept.cache.property.TransactionBoundCache(
         '_v_uncontained_content', dict)
 
@@ -205,14 +249,32 @@ class Repository(persistent.Persistent, Container):
         unique_id = self._get_normalized_unique_id(unique_id)
         if not unique_id.startswith(zeit.cms.interfaces.ID_NAMESPACE):
             raise ValueError("The id %r is invalid." % unique_id)
-        path = unique_id.replace(zeit.cms.interfaces.ID_NAMESPACE, '', 1)
-        if path.startswith('/'):
-            path = path[1:]
+        if unique_id == self.uniqueId:  # "root" edge case part 1b
+            return self
+
         try:
-            content = zope.traversing.interfaces.ITraverser(
-                self).traverse(path)
-        except zope.traversing.interfaces.TraversalError:
-            raise KeyError(unique_id)
+            # Performance optimization: Most content can be resolved directly
+            # via the connector, which is much faster than using traversal.
+            # To support this, content objects (via ContentBase above) are
+            # location-aware and can resolve their __parent__ themselves
+            # if it is needed (instead of the usual Zope paradigm that the
+            # container writes it on its children from the outside).
+            content = self.getUncontainedContent(unique_id)
+            # During traversal, IRepositoryContent happens in
+            # Container.__getitem__.
+            zope.interface.alsoProvides(
+                content, zeit.cms.repository.interfaces.IRepositoryContent)
+        except KeyError:
+            # Some content cannot be resolved directly, the most prominent
+            # example being zeit.content.dynamicfolder.
+            path = unique_id.replace(zeit.cms.interfaces.ID_NAMESPACE, '', 1)
+            if path.startswith('/'):
+                path = path[1:]
+            try:
+                content = zope.traversing.interfaces.ITraverser(
+                    self).traverse(path)
+            except zope.traversing.interfaces.TraversalError:
+                raise KeyError(unique_id)
         return content
 
     def getCopyOf(self, unique_id):

--- a/src/zeit/cms/repository/tests/test_repository.py
+++ b/src/zeit/cms/repository/tests/test_repository.py
@@ -144,14 +144,20 @@ class RepositoryTest(zeit.cms.testing.ZeitCmsTestCase):
                 [x.uniqueId for x in folder.values()])
 
 
-class RepositoryContentTest(zeit.cms.testing.ZeitCmsTestCase):
+class ContentBaseTest(zeit.cms.testing.ZeitCmsTestCase):
 
-    def test_result_implements_IRepositoryContent(self):
+    def test_implements_IRepositoryContent(self):
         self.assertTrue(
             zeit.cms.repository.interfaces.IRepositoryContent.providedBy(
                 self.repository.getContent('http://xml.zeit.de/testcontent')))
 
-    def test_result_has_parent(self):
+    def test_has_parent(self):
+        self.assertEqual(
+            self.repository['online']['2007']['01'],
+            self.repository.getContent(
+                'http://xml.zeit.de/online/2007/01/Somalia').__parent__)
+
+    def test_root_folder_is_repository(self):
         self.assertEqual(
             self.repository,
             self.repository.getContent(
@@ -162,3 +168,13 @@ class RepositoryContentTest(zeit.cms.testing.ZeitCmsTestCase):
             'testcontent',
             self.repository.getContent(
                 'http://xml.zeit.de/testcontent').__name__)
+
+    def test_can_write_explicit_parent(self):
+        one = zeit.cms.repository.repository.ContentBase()
+        one.__parent__ = 'foo'
+        self.assertEqual(one.__parent__, 'foo')
+
+    def test_can_write_none_to_parent(self):
+        one = zeit.cms.repository.repository.ContentBase()
+        one.__parent__ = None
+        self.assertIsNone(one.__parent__)

--- a/src/zeit/cms/repository/tests/test_repository.py
+++ b/src/zeit/cms/repository/tests/test_repository.py
@@ -142,3 +142,23 @@ class RepositoryTest(zeit.cms.testing.ZeitCmsTestCase):
             self.assertEquals(
                 ['http://xml.zeit.de/cache/one'],
                 [x.uniqueId for x in folder.values()])
+
+
+class RepositoryContentTest(zeit.cms.testing.ZeitCmsTestCase):
+
+    def test_result_implements_IRepositoryContent(self):
+        self.assertTrue(
+            zeit.cms.repository.interfaces.IRepositoryContent.providedBy(
+                self.repository.getContent('http://xml.zeit.de/testcontent')))
+
+    def test_result_has_parent(self):
+        self.assertEqual(
+            self.repository,
+            self.repository.getContent(
+                'http://xml.zeit.de/testcontent').__parent__)
+
+    def test_result_has_name(self):
+        self.assertEqual(
+            'testcontent',
+            self.repository.getContent(
+                'http://xml.zeit.de/testcontent').__name__)

--- a/src/zeit/cms/repository/unknown.py
+++ b/src/zeit/cms/repository/unknown.py
@@ -2,13 +2,13 @@ from zeit.cms.i18n import MessageFactory as _
 import persistent
 import zeit.cms.content.interfaces
 import zeit.cms.repository.interfaces
+import zeit.cms.repository.repository
 import zeit.cms.type
 import zeit.cms.util
-import zope.app.container.contained
 import zope.interface
 
 
-class UnknownResource(zope.app.container.contained.Contained):
+class UnknownResource(zeit.cms.repository.repository.ContentBase):
     """Represent an unknown resource"""
 
     zope.interface.implements(zeit.cms.repository.interfaces.IUnknownResource,
@@ -21,11 +21,6 @@ class UnknownResource(zope.app.container.contained.Contained):
             raise TypeError('data must be unicode.')
         self.data = data
         self.type = type_info
-
-    def __repr__(self):
-        return '<%s.%s %s>' % (
-            self.__class__.__module__, self.__class__.__name__,
-            self.uniqueId or '(unknown)')
 
 
 class PersistentUnknownResource(UnknownResource,


### PR DESCRIPTION
This can be a massive performance improvement (in the order of 5x), when in
a non-zope.security context, i.e. where no __parent__ chain is needed, and
should not carry a penalty when it is (traversal: resolve every folder from
top to bottom; dynamic parents: resolve every folder from bottom to top).

The code is inspired by monkey patches that have been used successfully in
zeit.web for a few years now.