### PR TITLE
BUG-846: Work around celery vs. DAV-cache race condition for "save+publish"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ zeit.cms changes
 3.3.1 (unreleased)
 ------------------
 
+- BUG-846: Work around celery vs. DAV-cache race condition for "save+publish"
+
 - MAINT: Remove trisolute current topics service, it's not used anymore
 
 

--- a/src/zeit/cms/workflow/interfaces.py
+++ b/src/zeit/cms/workflow/interfaces.py
@@ -119,7 +119,7 @@ def publish_priority_default(context):
 class IPublish(zope.interface.Interface):
     """Interface for publishing/unpublishing objects."""
 
-    def publish(priority=None, async=True):
+    def publish(priority=None, async=True, **kw):
         """Publish object.
 
         Before the object is published a BeforePublishEvent is issued.
@@ -130,9 +130,10 @@ class IPublish(zope.interface.Interface):
         the publish task in a separate, single-threaded Queue.
         Pass async=False if you want to execute publishing synchronously.
 
+        `kw` is passed through to the underlying celery task.
         """
 
-    def retract(priority=None, async=True):
+    def retract(priority=None, async=True, **kw):
         """Retract an object.
 
         Before the object is published a BeforeRetractEvent is issued.

--- a/src/zeit/cms/workflow/mock.py
+++ b/src/zeit/cms/workflow/mock.py
@@ -18,7 +18,7 @@ class MockPublish(object):
     def __init__(self, context):
         self.context = context
 
-    def publish(self, priority=PRIORITY_DEFAULT, async=True):
+    def publish(self, priority=PRIORITY_DEFAULT, async=True, **kw):
         can_publish = zeit.cms.workflow.interfaces.IPublishInfo(
             self.context).can_publish()
         if can_publish != CAN_PUBLISH_SUCCESS:
@@ -33,7 +33,7 @@ class MockPublish(object):
             zeit.cms.workflow.interfaces.PublishedEvent(self.context,
                                                         self.context))
 
-    def retract(self, priority=PRIORITY_DEFAULT, async=True):
+    def retract(self, priority=PRIORITY_DEFAULT, async=True, **kw):
         zope.event.notify(
             zeit.cms.workflow.interfaces.BeforeRetractEvent(self.context,
                                                             self.context))
@@ -43,7 +43,8 @@ class MockPublish(object):
             zeit.cms.workflow.interfaces.RetractedEvent(self.context,
                                                         self.context))
 
-    def publish_multiple(self, objects, priority=PRIORITY_LOW, async=True):
+    def publish_multiple(
+            self, objects, priority=PRIORITY_LOW, async=True, **kw):
         for obj in objects:
             obj = zeit.cms.interfaces.ICMSContent(obj)
             self.publish(obj, priority, async)

--- a/src/zeit/workflow/browser/README.txt
+++ b/src/zeit/workflow/browser/README.txt
@@ -443,8 +443,10 @@ other information
 
     >>> def run_tasks():
     ...     """Wait for already enqueued publish job, by running another job;
-    ...     since we only have on worker, this works out fine."""
-    ...     zeit.cms.testing.celery_ping.delay().get()
+    ...     since we only have on worker, this works out fine.
+    ...     Unfortunately we have to mimic the DAV-cache race condition
+    ...     workaround here too and wait an additional 5 seconds, sigh."""
+    ...     zeit.cms.testing.celery_ping.apply_async(countdown=5).get()
 
 .. [#needs-repository]
 


### PR DESCRIPTION
So richtig happy bin ich mit der Sache nicht:

1. Wir müssen jetzt domain-fremdes Zeug durchs IPublish Interface durchschleifen, also celery-Kontrollanweisungen, die mit "publish" gar nix zu tun haben
1. Im Browsertest muss man jetzt jedesmal 5s extra warten

Ich fürchte aber, um 1. kommen wir nicht herum, und ob es sich lohnt wegen 2. eine Monkeypatch-Orgie anzufangen, bin ich auch eher skeptisch. Le sigh.

Siehe [BUG-846](https://zeit-online.atlassian.net/browse/BUG-846)