### PR TITLE
TMS-186: Implement SSO-style cookie generating login view

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.cms changes
 ================
 
-3.5.2 (unreleased)
+3.6.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- TMS-186: Implement SSO-style cookie generating login view
 
 
 3.5.1 (2018-03-06)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.cms',
-    version='3.5.2.dev0',
+    version='3.6.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',
@@ -59,6 +59,7 @@ setup(
         'sprout',
         'tblib',
         'transaction',
+        'webob',
         'werkzeug',
         'z3c.celery >= 1.2.0.dev0',
         'z3c.conditionalviews>=1.0b2.dev-r91510',

--- a/src/zeit/cms/browser/skin.zcml
+++ b/src/zeit/cms/browser/skin.zcml
@@ -95,5 +95,13 @@
     layer="zeit.cms.browser.interfaces.ICMSLayer"
     />
 
+  <browser:page
+    for="zope.traversing.interfaces.IContainmentRoot"
+    class=".login.SSOLogin"
+    permission="zope.Public"
+    name="sso-login"
+    layer="zeit.cms.browser.interfaces.ICMSLayer"
+    />
+
 </configure>
 

--- a/src/zeit/cms/testing.py
+++ b/src/zeit/cms/testing.py
@@ -322,6 +322,9 @@ cms_product_config = """\
   breadcrumbs-use-common-metadata true
 
   cache-expiration-config 600
+
+  sso-cookie-name-prefix my_sso_
+  sso-cookie-domain
 </product-config>
 """.format(base=pkg_resources.resource_filename(__name__, ''))
 


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/vivi-deployment/commit/a68c0dac8f9f519f6415b6977a0f0790ba30b933 which I pushed directly to master as usual (since its strictly additive) instead of PRing (maybe revise that workflow?)