### PR TITLE
BUG-890: Store title and type in clipboard entries, so we don't have to resolve the content to render the clipboard

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ zeit.cms changes
 3.6.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BUG-890: Store title and type in clipboard entries, so we don't have
+  to resolve the content to render the clipboard
 
 
 3.6.6 (2018-03-22)

--- a/src/zeit/cms/clipboard/browser/README.txt
+++ b/src/zeit/cms/clipboard/browser/README.txt
@@ -488,8 +488,7 @@ Let's have a look at the sidebar:
   <ul>
       <li class="NotRoot..." uniqueid="wirtschaft.feed">
         <p>
-        <a href="http://localhost/++skin++cms/workingcopy/zope.user/zeit.cms.clipboard.clipboard.Clipboard/wirtschaft.feed">Broken
-            reference to http://xml.zeit.de/wirtschaft.feed</a>
+        <a href="http://localhost/++skin++cms/workingcopy/zope.user/zeit.cms.clipboard.clipboard.Clipboard/wirtschaft.feed">Wirtschaft</a>
         ...
 
 
@@ -542,7 +541,7 @@ Reload the whole page and verify the title change:
       <ul>
         <li class="NotRoot..." uniqueid="wirtschaft.feed">
           <p>
-          <a href="...wirtschaft.feed">Broken reference ...</a>
+          <a href="...wirtschaft.feed">Wirtschaft</a>
           ...
         </li>
         <li action="collapse" class="NotRoot..." uniqueid="New Clip">
@@ -603,7 +602,7 @@ Open "New clip", we have a delete link there:
       <ul>
         <li class="NotRoot..." uniqueid="wirtschaft.feed">
           <p>
-          <a href="...wirtschaft.feed">Broken reference ...</a>
+          <a href="...wirtschaft.feed">Wirtschaft</a>
           ...
         </li>
       </ul>

--- a/src/zeit/cms/clipboard/browser/clipboard.py
+++ b/src/zeit/cms/clipboard/browser/clipboard.py
@@ -68,26 +68,15 @@ class Tree(zeit.cms.browser.tree.Tree):
         return self()
 
     def getTitle(self, obj):
-        if zeit.cms.clipboard.interfaces.IClip.providedBy(obj):
+        if (zeit.cms.clipboard.interfaces.IObjectReference.providedBy(obj) or
+                zeit.cms.clipboard.interfaces.IClip.providedBy(obj)):
             return obj.title
-        else:
-            list_repr = zope.component.queryMultiAdapter(
-                (obj, self.request),
-                zeit.cms.browser.interfaces.IListRepresentation)
-            if list_repr is not None and list_repr.title:
-                return list_repr.title
         return super(Tree, self).getTitle(obj)
 
     def getType(self, obj):
         if not zeit.cms.clipboard.interfaces.IObjectReference.providedBy(obj):
             return ''
-
-        for interface in zope.interface.providedBy(obj.references):
-            try:
-                return interface.getTaggedValue('zeit.cms.type')
-            except KeyError:
-                continue
-        return ''
+        return obj.content_type
 
     def getAddContext(self, add_to):
         if add_to:

--- a/src/zeit/cms/clipboard/interfaces.py
+++ b/src/zeit/cms/clipboard/interfaces.py
@@ -20,6 +20,14 @@ class IObjectReference(IClipboardEntry):
         title=u"Unique Id o the referenced object.",
         readonly=True)
 
+    title = zope.schema.TextLine(
+        title=u'Title of the referenced object',
+        readonly=True)
+
+    content_type = zope.schema.TextLine(
+        title=u'Content type of the referenced object',
+        readonly=True)
+
 
 class IClipSchema(zope.interface.Interface):
     """Clip schema."""


### PR DESCRIPTION
## Migrationsskript

Sollte man vor dem Production-Deployment laufen lassen (wird aber vmtl. ne ganze Weile dauern)

```python
import logging
import transaction
import zeit.cms.clipboard.entry
import zeit.cms.clipboard.interfaces
import zeit.cms.type
import zope.component
import zope.component.hooks

log = logging.getLogger('migrate')
zope.component.hooks.setSite(root)  # noqa
workingcopy = root['workingcopy']  # noqa


def main():
    for wc in workingcopy.values():
        log.info('Processing %s', wc.__name__)
        try:
            clipboard = zeit.cms.clipboard.interfaces.IClipboard(wc)

            todo = {}
            for item in traverse(clipboard):
                data = {}
                obj = item.references
                if obj is None:
                    continue
                data['title'] = get_title(obj)
                data['content_type'] = zeit.cms.type.get_type(obj)
                todo[item] = data
                if len(todo) % 10 == 0:
                    log.info('... %s entries', len(todo))
            transaction.abort()  # throw away DAV cache changes

            log.info('Migrating')
            zeit.cms.testing.create_interaction(wc.__name__)
            for clip, data in todo.items():
                for name, value in data.items():
                    setattr(clip, name, value)
            log.info('commit')
            transaction.commit()
        except Exception:
            transaction.abort()
            log.error('Error occurred during %s', wc.__name__, exc_info=True)
        finally:
            zope.security.management.endInteraction()


def traverse(node):
    if zeit.cms.clipboard.interfaces.IClip.providedBy(node):
        for child in node.values():
            for item in traverse(child):
                yield item
    else:
        yield node


def get_title(obj):
    list_repr = zope.component.queryMultiAdapter(
        (obj, zeit.cms.clipboard.entry.Entry._request),
        zeit.cms.browser.interfaces.IListRepresentation)
    if list_repr is not None and list_repr.title:
        return list_repr.title


main()
```