### PR TITLE
ZON-4581: Move banner checkbox from option to admin tab

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.cms changes
 3.6.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ZON-4581: Move banner checkbox from option to admin tab
 
 
 3.6.6 (2018-03-22)

--- a/src/zeit/cms/admin/browser/admin.py
+++ b/src/zeit/cms/admin/browser/admin.py
@@ -20,6 +20,8 @@ class EditFormCO(zeit.cms.browser.form.EditForm):
 
     form_fields = zope.formlib.form.Fields(
         zeit.cms.content.interfaces.ICommonMetadata).select(
+        'banner') + zope.formlib.form.Fields(
+        zeit.cms.content.interfaces.ICommonMetadata).select(
         'banner_content')
 
     # Without field group it will look weird when context is an Article.

--- a/src/zeit/cms/admin/tests/test_banner.py
+++ b/src/zeit/cms/admin/tests/test_banner.py
@@ -1,0 +1,40 @@
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
+import pytz
+import zeit.cms.content.interfaces
+import zeit.cms.testing
+
+class TestBannerDisplayCheckbox(
+    zeit.cms.testing.ZeitCmsBrowserTestCase):
+
+    login_as = 'zmgr:mgrpw'
+    def test_banner_has_checkbox(self):
+        self.browser.open(
+            'http://localhost:8080/++skin++vivi/repository/testcontent')
+        self.browser.getLink('Checkout').click()
+        self.assertIn('fieldname-banner', self.browser.contents)
+
+
+class TestBannerDisplay(zeit.cms.testing.ZeitCmsTestCase):
+
+    def setUp(self):
+        super(TestBannerDisplay, self).setUp()
+        self.content = ExampleContentType()
+
+    def test_banner_has_correct_default_value(
+            self):
+        self.assertFalse(
+            zeit.cms.content.interfaces.ICommonMetadata(
+            self.content).banner)
+
+    def test_banner_correct_stored_value(
+            self):
+        zeit.cms.content.interfaces.ICommonMetadata(
+            self.content).banner = False
+        self.assertFalse(
+            zeit.cms.content.interfaces.ICommonMetadata(
+            self.content).banner)
+        zeit.cms.content.interfaces.ICommonMetadata(
+            self.content).banner = True
+        self.assertTrue(
+            zeit.cms.content.interfaces.ICommonMetadata(
+            self.content).banner)

--- a/src/zeit/cms/content/browser/form.py
+++ b/src/zeit/cms/content/browser/form.py
@@ -26,7 +26,7 @@ class CommonMetadataFormBase(zeit.cms.browser.form.CharlimitMixin):
         _("Options"),
         ('dailyNewsletter', 'commentsAllowed', 'commentSectionEnable',
          'foldable',
-         'minimal_header', 'countings', 'banner', 'banner_id', 'breaking_news',
+         'minimal_header', 'countings', 'banner_id', 'breaking_news',
          'mobile_alternative', 'rebrush_website_content', 'overscrolling'),
         css_class='column-right checkboxes')
     author_fields = gocept.form.grouped.Fields(


### PR DESCRIPTION
Soweit `grep` reicht, scheint die Checkbox nur noch für die Videos über ein anderes Formular zu kommen. Die meisten Tests können allgemein so bleiben wie bisher, da die generell auf Metadaten prüfen und der Umzug des Feldes nach Admin daran nichts ändert. Für das Form habe ich einen Test hinzugefügt.