### PR TITLE
ZON-5026: Add banner_outer to admin view

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ zeit.cms changes
 3.20.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-5026: Add `banner_outer` to admin tab
 
 
 3.20.0 (2019-01-09)

--- a/src/zeit/cms/admin/browser/admin.py
+++ b/src/zeit/cms/admin/browser/admin.py
@@ -20,7 +20,8 @@ class EditFormCO(zeit.cms.browser.form.EditForm):
 
     form_fields = zope.formlib.form.Fields(
         zeit.cms.content.interfaces.ICommonMetadata).select(
-        'banner', 'banner_content', 'hide_adblocker_notification')
+        'banner', 'banner_content', 'banner_outer',
+        'hide_adblocker_notification')
 
     # Without field group it will look weird when context is an Article.
     field_groups = (gocept.form.grouped.RemainingFields(

--- a/src/zeit/cms/admin/tests/test_bannerouter.py
+++ b/src/zeit/cms/admin/tests/test_bannerouter.py
@@ -1,0 +1,41 @@
+from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
+import zeit.cms.content.interfaces
+import zeit.cms.testing
+
+
+class TestBannerOuterDisplayCheckbox(
+        zeit.cms.testing.ZeitCmsBrowserTestCase):
+
+    login_as = 'zmgr:mgrpw'
+
+    def test_banner_outer_has_checkbox(self):
+        self.browser.open(
+            'http://localhost:8080/++skin++vivi/repository/testcontent')
+        self.browser.getLink('Checkout').click()
+        self.assertIn('fieldname-banner', self.browser.contents)
+
+
+class TestBannerOuterDisplay(zeit.cms.testing.ZeitCmsTestCase):
+
+    def setUp(self):
+        super(TestBannerOuterDisplay, self).setUp()
+        self.content = ExampleContentType()
+
+    def test_banner_outer_has_correct_default_value(
+            self):
+        self.assertTrue(
+            zeit.cms.content.interfaces.ICommonMetadata(
+                self.content).banner_outer)
+
+    def test_banner_outer_correct_stored_value(
+            self):
+        zeit.cms.content.interfaces.ICommonMetadata(
+            self.content).banner_outer = False
+        self.assertFalse(
+            zeit.cms.content.interfaces.ICommonMetadata(
+                self.content).banner_outer)
+        zeit.cms.content.interfaces.ICommonMetadata(
+            self.content).banner_outer = True
+        self.assertTrue(
+            zeit.cms.content.interfaces.ICommonMetadata(
+                self.content).banner_outer)

--- a/src/zeit/cms/content/interfaces.py
+++ b/src/zeit/cms/content/interfaces.py
@@ -227,7 +227,7 @@ class ICommonMetadata(zope.interface.Interface):
         default=True)
 
     banner_outer = zope.schema.Bool(
-        title=_("Banner out of Content"),
+        title=_("Banner Mainad"),
         required=False,
         default=True)
 

--- a/src/zeit/cms/content/interfaces.py
+++ b/src/zeit/cms/content/interfaces.py
@@ -226,6 +226,11 @@ class ICommonMetadata(zope.interface.Interface):
         required=False,
         default=True)
 
+    banner_outer = zope.schema.Bool(
+        title=_("Banner out of Content"),
+        required=False,
+        default=True)
+
     banner_id = zope.schema.TextLine(
         title=_('Banner id'),
         required=False)

--- a/src/zeit/cms/content/metadata.py
+++ b/src/zeit/cms/content/metadata.py
@@ -29,7 +29,6 @@ class CommonMetadata(zeit.cms.content.xmlsupport.XMLContentBase):
 
         'banner',
         'banner_content',
-        'banner_outer',
         'hide_adblocker_notification',
         'lead_candidate',
         'overscrolling',
@@ -105,7 +104,7 @@ class CommonMetadata(zeit.cms.content.xmlsupport.XMLContentBase):
         ICommonMetadata['storystreams'], DOCUMENT_SCHEMA_NS,
         'storystreams', use_default=True)
 
-    banner_outer = zeit.cms.content.DAVProperty(
+    banner_outer = zeit.cms.content.dav.DAVProperty(
         ICommonMetadata['banner_outer'], DOCUMENT_SCHEMA_NS, 'banner_outer',
         use_default=True)
 

--- a/src/zeit/cms/content/metadata.py
+++ b/src/zeit/cms/content/metadata.py
@@ -29,6 +29,7 @@ class CommonMetadata(zeit.cms.content.xmlsupport.XMLContentBase):
 
         'banner',
         'banner_content',
+        'banner_outer',
         'hide_adblocker_notification',
         'lead_candidate',
         'overscrolling',

--- a/src/zeit/cms/content/metadata.py
+++ b/src/zeit/cms/content/metadata.py
@@ -105,6 +105,10 @@ class CommonMetadata(zeit.cms.content.xmlsupport.XMLContentBase):
         ICommonMetadata['storystreams'], DOCUMENT_SCHEMA_NS,
         'storystreams', use_default=True)
 
+    banner_outer = zeit.cms.content.DAVProperty(
+        ICommonMetadata['banner_outer'], DOCUMENT_SCHEMA_NS, 'banner_outer',
+        use_default=True)
+
 
 @grok.subscribe(ICommonMetadata, zope.lifecycleevent.IObjectModifiedEvent)
 def set_default_channel_to_ressort(context, event):


### PR DESCRIPTION
Adds the option to disable the `mainad` inside the admin view.

Please add the missing translations for `Banner mainad` inside `zeit.locales`..
The translation shall be `Außenwerbung`
Also, please update these Translations:
`Banner` -> `Alle Werbung`
`Banner im Content` -> `Werbung im Artikeltext`

thaanks!