### PR TITLE
ZON-5091: Add color as an attribute of Serie

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,10 +1,10 @@
 zeit.cms changes
 ================
 
-3.20.2 (unreleased)
+3.21.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- ZON-5091: Add color as an attribute of Serie
 
 
 3.20.1 (2019-01-22)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zeit.cms',
-    version='3.20.2.dev0',
+    version='3.21.0.dev0',
     author='gocept, Zeit Online',
     author_email='zon-backend@zeit.de',
     url='http://www.zeit.de/',

--- a/src/zeit/cms/content/sources.py
+++ b/src/zeit/cms/content/sources.py
@@ -339,7 +339,7 @@ class Serie(AllowedBase):
 
     def __init__(self, serienname=None, title=None, url=None, encoded=None,
                  column=False, kind=None, video=False, fallback_image=False,
-                 podigee_id=None):
+                 podigee_id=None, color=None):
         super(Serie, self).__init__(serienname, title, None)
         self.id = serienname
         self.serienname = serienname
@@ -351,6 +351,7 @@ class Serie(AllowedBase):
         self.video = video
         self.fallback_image = fallback_image
         self.podigee_id = podigee_id
+        self.color = color
 
     def __eq__(self, other):
         if not zope.security.proxy.isinstance(other, self.__class__):
@@ -380,7 +381,8 @@ class SerieSource(ObjectSource, SimpleContextualXMLSource):
                 unicode_or_none(node.get('kind')),
                 node.get('video') == u'yes',
                 node.get('fallback_image') == u'yes',
-                unicode_or_none(node.get('podigee-id'))
+                unicode_or_none(node.get('podigee-id')),
+                unicode_or_none(node.get('color'))
             )
         return result
 


### PR DESCRIPTION
Adds another attribute to the series source for use with podcast teasers and as fill color for podcast images.